### PR TITLE
Aligning search query editor to Phoebus counterpart

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-perfect-scrollbar": "^1.5.8",
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.1",
+    "react-transition-group": "^4.4.2",
     "remarkable": "^2.0.1"
   },
   "scripts": {

--- a/src/Filters.js
+++ b/src/Filters.js
@@ -34,7 +34,7 @@ import DateTimePicker from 'react-datetime-picker';
 class Filters extends Component{
 
     state = {
-        openLogbooks: true,
+        openLogbooks: false,
         openTags: false,
         openTimespan: false,
         openFromTo: false,
@@ -199,32 +199,116 @@ class Filters extends Component{
         let timeSpans = ["12 hours", "1 day", "3 days", "7 days"];
 
         return(
-            <Container className="grid-item filters full-height" style={{paddingLeft: "5px", paddingRight: "5px"}}>
-              <h6>Filter Log Entries</h6>
-                <Accordion defaultActiveKey="0">
-                    <Accordion.Toggle eventKey="0" onClick={() => this.setState({openLogbooks: !this.state.openLogbooks})} 
-                        className="accordion-card-header">
-                        {this.state.openLogbooks ? <FaChevronDown /> : <FaChevronRight/> } Logbooks
-                    </Accordion.Toggle>
-                    <Accordion.Collapse eventKey="0">
-                       <Logbooks 
-                        logbooks={this.props.logbooks} 
-                        searchCriteria={this.state.searchCriteria}
-                        addLogbookToSearchCriteria={this.addLogbookToSearchCriteria}/>
-                    </Accordion.Collapse>
-                </Accordion>
-                <Accordion>
-                    <Accordion.Toggle eventKey="0" onClick={() => this.setState({openTags: !this.state.openTags})}
-                         className="accordion-card-header">
-                        {this.state.openTags ? <FaChevronDown /> : <FaChevronRight/> } Tags
-                    </Accordion.Toggle>
-                    <Accordion.Collapse eventKey="0">
-                       <Tags tags={this.props.tags}
-                            searchCriteria={this.state.searchCriteria}
-                            addTagToSearchCriteria={this.addTagToSearchCriteria}/>
-                    </Accordion.Collapse>
-                </Accordion>
-                <Accordion>
+            <Container className="grid-item filters full-height" style={{padding: "8px"}}>
+                <Table size="sm" className="search-fields-table">
+                    <tbody>
+                        <tr>
+                            <td>Title:</td>
+                            <td></td>
+                        </tr>
+                        <tr>
+                            <td style={{width: "100%"}}>
+                                <Form.Control size="sm"
+                                    type="text"
+                                    value={this.state.searchCriteria.title}
+                                    onChange={this.titleChanged}></Form.Control>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Text:</td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <Form.Control size="sm"
+                                    type="text"
+                                    value={this.state.searchCriteria.text}
+                                    onChange={this.textChanged}></Form.Control>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Level:</td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <Form.Control size="sm"
+                                    type="text"
+                                    value={this.state.searchCriteria.level}
+                                    onChange={this.levelChanged}></Form.Control>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><Accordion>
+                                <Accordion.Toggle eventKey="0" onClick={() => this.setState({openLogbooks: !this.state.openLogbooks})}
+                                    className="accordion-card-header">
+                                    {this.state.openLogbooks ? <FaChevronDown /> : <FaChevronRight/> } Logbooks
+                                </Accordion.Toggle>
+                                <Accordion.Collapse eventKey="0">
+                                   <Logbooks
+                                    logbooks={this.props.logbooks}
+                                    searchCriteria={this.state.searchCriteria}
+                                    addLogbookToSearchCriteria={this.addLogbookToSearchCriteria}/>
+                                </Accordion.Collapse>
+                           </Accordion></td>
+                        </tr>
+                        <tr>
+                            <td><Accordion>
+                                <Accordion.Toggle eventKey="0" onClick={() => this.setState({openTags: !this.state.openTags})}
+                                     className="accordion-card-header">
+                                    {this.state.openTags ? <FaChevronDown /> : <FaChevronRight/> } Tags
+                                </Accordion.Toggle>
+                                <Accordion.Collapse eventKey="0">
+                                   <Tags tags={this.props.tags}
+                                        searchCriteria={this.state.searchCriteria}
+                                        addTagToSearchCriteria={this.addTagToSearchCriteria}/>
+                                </Accordion.Collapse>
+                            </Accordion></td>
+                        </tr>
+                        <tr>
+                            <td>Author:</td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <Form.Control size="sm"
+                                    type="text"
+                                    value={this.state.searchCriteria.owner}
+                                    onChange={this.authorChanged}></Form.Control>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Time:</td>
+                        </tr>
+                        <tr>
+                            <td>Start Time:</td>
+                        </tr>
+                        <tr>
+                            <td>
+                            <DateTimePicker
+                                onChange={(value) => this.setStartDate(value)}
+                                style={{width:30}}
+                                value={this.state.startDate}
+                                format='y-MM-dd HH:mm'
+                                clearIcon=""
+                                disableClock></DateTimePicker>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style={{width: "40px"}}>End Time:</td>
+                        </tr>
+                        <tr>
+                            <td>
+                            <DateTimePicker
+                                onChange={(value) => this.setEndDate(value)}
+                                value={this.state.endDate}
+                                format='y-MM-dd HH:mm'
+                                clearIcon=""
+                                disableClock></DateTimePicker>
+                            </td>
+                        </tr>
+                    </tbody>
+                </Table>
+
+
+                {/*<Accordion>
                     <Accordion.Toggle eventKey="0" onClick={() => this.setState({openTimespan: !this.state.openTimespan})}
                         className="accordion-card-header">
                         {this.state.openTimespan ? <FaChevronDown /> : <FaChevronRight/> } Created since
@@ -244,7 +328,7 @@ class Filters extends Component{
                             ))}
                         </ul>
                     </Accordion.Collapse>
-                </Accordion>
+                </Accordion>}
                 <Accordion>
                     <Accordion.Toggle eventKey="0" onClick={() => this.setState({openFromTo: !this.state.openFromTo})}
                         className="accordion-card-header">
@@ -279,55 +363,7 @@ class Filters extends Component{
                         </Table>
                        
                     </Accordion.Collapse>
-                </Accordion>
-                <Accordion>
-                    <Accordion.Toggle eventKey="0" onClick={() => this.setState({openOther: !this.state.openOther})}
-                        className="accordion-card-header">
-                        {this.state.openOther ? <FaChevronDown /> : <FaChevronRight/> } Other search fields
-                    </Accordion.Toggle>
-                    <Accordion.Collapse eventKey="0">
-                        <Table size="sm" className="search-fields-table">
-                            <tbody>
-                                <tr>
-                                    <td>Title:</td>
-                                    <td style={{width: "100%"}}>
-                                        <Form.Control size="sm" 
-                                            type="text" 
-                                            value={this.state.searchCriteria.title}
-                                            onChange={this.titleChanged}></Form.Control>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>Text:</td>
-                                    <td>
-                                        <Form.Control size="sm" 
-                                            type="text" 
-                                            value={this.state.searchCriteria.text}
-                                            onChange={this.textChanged}></Form.Control>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>Level:</td>
-                                    <td>
-                                        <Form.Control size="sm" 
-                                            type="text" 
-                                            value={this.state.searchCriteria.level}
-                                            onChange={this.levelChanged}></Form.Control>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>Author:</td>
-                                    <td>
-                                        <Form.Control size="sm" 
-                                            type="text" 
-                                            value={this.state.searchCriteria.owner}
-                                            onChange={this.authorChanged}></Form.Control>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </Table>
-                    </Accordion.Collapse>
-                </Accordion>
+                </Accordion>*/}
             </Container>
         )
     }

--- a/src/LogDetailsMetaData.js
+++ b/src/LogDetailsMetaData.js
@@ -26,16 +26,22 @@
     render (){        
         
         var logbooks = this.props.currentLogRecord && this.props.currentLogRecord.logbooks.sort((a, b) => a.name.localeCompare(b.name)).map((row, index) => {
-            return (
-                <span key={index}>{row.name}&nbsp;</span>
-            )}
-        )
+            if(index === this.props.currentLogRecord.logbooks.length - 1){
+                return(<span key={index}>{row.name}</span>);
+            }
+            else{
+                return (<span key={index}>{row.name},&nbsp;</span>);
+            }    
+        });
     
         var tags = this.props.currentLogRecord && this.props.currentLogRecord.tags.sort((a, b) => a.name.localeCompare(b.name)).map((row, index) => {
-            return (
-                <span key={index}>{row.name}&nbsp;</span>
-            )}
-        )    
+            if(index === this.props.currentLogRecord.tags.length - 1){
+                return(<span key={index}>{row.name}</span>);
+            }
+            else{
+                return (<span key={index}>{row.name},&nbsp;</span>);
+            } 
+        });    
         
         return (
             <div className="log-details-meta-data">

--- a/src/MainApp.js
+++ b/src/MainApp.js
@@ -24,57 +24,73 @@ import Container from 'react-bootstrap/Container'
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Collapse from 'react-bootstrap/Collapse';
+import customization from './customization';
+import {queryStringToSearchParameters, setSearchParam, searchParamsToQueryString} from './utils.js';
+import Cookies from 'universal-cookie';
+
 
 /**
  * Top level component holding the main UI area components.
  */
 class MainApp extends Component {
 
-  state = {
-      logEntryTree: [],
-      searchString: "start=12 hours&end=now",
-      selectedLogEntryId: 0,
-      searchResult: [],
-      searchInProgress: false,
-      sortAscending: false,
-      logGroupRecords: [],
-      showFilters: false
-    };
+    state = {
+          logEntryTree: [],
+          selectedLogEntryId: 0,
+          searchResult: [],
+          searchInProgress: false,
+          logGroupRecords: [],
+          showFilters: false,
+          searchParams: {}
+        };
 
-  search = () => {
+    cookies = new Cookies();
 
-    this.setState({searchInProgress: true}, () => {
-    fetch(`${process.env.REACT_APP_BASE_URL}/logs?` + this.state.searchString)
-      .then(response => {if(response.ok){return response.json();} else {return []}})
-      .then(data => {
-        this.setState({searchResult: data, searchInProgress: false});
-      })
-      .catch(() => {this.setState({searchInProgress: false}); alert("Olog service off-line?");})});
-  }
+    componentDidMount = () => {
+        let persistedSearchString = this.cookies.get('searchString');
+        if(persistedSearchString){
+            this.setState({searchParams: queryStringToSearchParameters(persistedSearchString)});
+        }
+        else{
+            this.setState({searchParams: customization.defaultSearchParams});
+        }
+    }
 
-  setCurrentLogEntry = (logEntry) => {
-      this.setState({selectedLogEntryId: logEntry.id});
-      this.props.setCurrentLogEntry(logEntry);
-      this.setState({showGroup: false});
-  }
+    search = () => {
+        this.setState({searchInProgress: true}, () => {
+        fetch(`${process.env.REACT_APP_BASE_URL}/logs?` + searchParamsToQueryString(this.state.searchParams))
+          .then(response => {if(response.ok){return response.json();} else {return []}})
+          .then(data => {
+            this.setState({searchResult: data, searchInProgress: false});
+          })
+          .catch(() => {this.setState({searchInProgress: false}); alert("Olog service off-line?");})});
+    }
 
-  setSearchString = (searchString, performSearch) => {
-    this.setState({searchString: searchString});
-  }
+    setCurrentLogEntry = (logEntry) => {
+        this.setState({selectedLogEntryId: logEntry.id});
+        this.props.setCurrentLogEntry(logEntry);
+        this.setState({showGroup: false});
+    }
 
-  setSortAscending = (ascending) => {
-    this.setState({sortAscending: ascending});
-  }
+    setSortOrder = (sortOrder) => {
+        let augmentedSortParams = setSearchParam(this.state.searchParams, 'sort', sortOrder);
+        this.setState({searchParams: augmentedSortParams});
+    }
 
-  setLogGroupRecords = (recs) => {
-    this.setState({logGroupRecords: recs});
-  }
+    setLogGroupRecords = (recs) => {
+        this.setState({logGroupRecords: recs});
+    }
 
-  toggleFilters = () => {
-    this.setState({showFilters: !this.state.showFilters});
-  }
+    toggleFilters = () => {
+        this.setState({showFilters: !this.state.showFilters});
+    }
+
+    setSearchParams = (params) => {
+        this.setState({searchParams: params});
+    }
 
   render() {
+
     return (
       <>
         <Container fluid className="full-height">
@@ -82,20 +98,19 @@ class MainApp extends Component {
             <Collapse in={this.state.showFilters}>
                 <Col xs={{span: 12, order: 3}} sm={{span: 12, order: 3}} md={{span: 12, order: 3}} lg={{span: 2, order: 1}} style={{padding: "2px"}}>
                   <Filters
-                    logbooks={this.props.logbooks}
-                    tags={this.props.tags}
-                    setSearchString={this.setSearchString}/>
+                    {...this.state} {...this.props}
+                    setSearchParams={this.setSearchParams}/>
                 </Col>
             </Collapse>
             <Col xs={{span: 12, order: 2}} sm={{span: 12, order: 2}} md={{span: 12, order: 2}} lg={{span: 4, order: 2}} style={{padding: "2px"}}>
               <SearchResultList {...this.state} {...this.props}
                 setCurrentLogEntry={this.setCurrentLogEntry}
-                setSearchString={this.setSearchString}
+                setSearchParams={this.setSearchParams}
                 search={this.search}
-                setSortAscending={this.setSortAscending}
-                toggleFilters={this.toggleFilters}/>
+                toggleFilters={this.toggleFilters}
+                setSortOrder={this.setSortOrder}/>
             </Col>
-            <Col  xs={{span: 12, order: 1}} sm={{span: 12, order: 1}} md={{span: 12, order: 1}} lg={{span: 6, order: 3}} style={{padding: "2px"}}>
+            <Col  xs={{span: 12, order: 1}} sm={{span: 12, order: 1}} md={{span: 12, order: 1}} lg={{span: this.state.showFilters ? 6 : 8, order: 3}} style={{padding: "2px"}}>
               <LogDetails {...this.state} {...this.props}
                 setCurrentLogEntry={this.setCurrentLogEntry}
                 setReplyAction={this.props.setReplyAction}

--- a/src/MainApp.js
+++ b/src/MainApp.js
@@ -23,6 +23,7 @@ import SearchResultList from './SearchResultList';
 import Container from 'react-bootstrap/Container'
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
+import Collapse from 'react-bootstrap/Collapse';
 
 /**
  * Top level component holding the main UI area components.
@@ -37,6 +38,7 @@ class MainApp extends Component {
       searchInProgress: false,
       sortAscending: false,
       logGroupRecords: [],
+      showFilters: false
     };
 
   search = () => {
@@ -68,22 +70,30 @@ class MainApp extends Component {
     this.setState({logGroupRecords: recs});
   }
 
+  toggleFilters = () => {
+    this.setState({showFilters: !this.state.showFilters});
+  }
+
   render() {
     return (
       <>
         <Container fluid className="full-height">
           <Row className="full-height">
-            {<Col xs={{span: 12, order: 3}} sm={{span: 12, order: 3}} md={{span: 12, order: 3}} lg={{span: 2, order: 1}} style={{padding: "2px"}}>
-              <Filters logbooks={this.props.logbooks} 
-                tags={this.props.tags} 
-                setSearchString={this.setSearchString}/>
-            </Col>}
+            <Collapse in={this.state.showFilters}>
+                <Col xs={{span: 12, order: 3}} sm={{span: 12, order: 3}} md={{span: 12, order: 3}} lg={{span: 2, order: 1}} style={{padding: "2px"}}>
+                  <Filters
+                    logbooks={this.props.logbooks}
+                    tags={this.props.tags}
+                    setSearchString={this.setSearchString}/>
+                </Col>
+            </Collapse>
             <Col xs={{span: 12, order: 2}} sm={{span: 12, order: 2}} md={{span: 12, order: 2}} lg={{span: 4, order: 2}} style={{padding: "2px"}}>
               <SearchResultList {...this.state} {...this.props}
                 setCurrentLogEntry={this.setCurrentLogEntry}
                 setSearchString={this.setSearchString}
                 search={this.search}
-                setSortAscending={this.setSortAscending}/> 
+                setSortAscending={this.setSortAscending}
+                toggleFilters={this.toggleFilters}/>
             </Col>
             <Col  xs={{span: 12, order: 1}} sm={{span: 12, order: 1}} md={{span: 12, order: 1}} lg={{span: 6, order: 3}} style={{padding: "2px"}}>
               <LogDetails {...this.state} {...this.props}

--- a/src/SearchResultList.js
+++ b/src/SearchResultList.js
@@ -34,6 +34,10 @@ import Tooltip from 'react-bootstrap/Tooltip';
  */
 class SearchResultList extends Component{
 
+    state = {
+        expandSymbol: ">"
+    }
+
     componentDidMount = () => {
         this.props.search();
     }
@@ -69,6 +73,12 @@ class SearchResultList extends Component{
         </Popover>
       );
 
+    toggleFilters = () => {
+        this.props.toggleFilters();
+        let symbol = this.props.showFilters ? ">" : "<";
+        this.setState({expandSymbol: symbol});
+    }
+
     render(){
 
         var list = this.props.searchResult.map((item, index) => {
@@ -84,6 +94,9 @@ class SearchResultList extends Component{
             <Container className="grid-item full-height" style={{paddingLeft: "5px", paddingRight: "5px"}}>
                 <Form style={{paddingTop: "5px"}} onSubmit={(e) => this.submit(e)}>
                     <Form.Row>
+                        <Col style={{flexGrow: "0"}}>
+                            <Button size="sm" onClick={() => this.toggleFilters()}>{this.state.expandSymbol}</Button>
+                        </Col>
                         <Col style={{flexGrow: "0", paddingTop: "7px"}}>
                             <OverlayTrigger trigger="click"
                                 overlay={this.popover}

--- a/src/SearchResultList.js
+++ b/src/SearchResultList.js
@@ -25,8 +25,9 @@ import LoadingOverlay from 'react-loading-overlay';
 import { FaArrowUp, FaArrowDown} from "react-icons/fa";
 import Popover from 'react-bootstrap/Popover';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
-import {addSortOrder} from './utils';
+import {searchParamsToQueryString, queryStringToSearchParameters} from './utils';
 import Tooltip from 'react-bootstrap/Tooltip';
+import Cookies from 'universal-cookie';
 
 /**
  * Pane showing search query input and a the list of log entries 
@@ -35,27 +36,32 @@ import Tooltip from 'react-bootstrap/Tooltip';
 class SearchResultList extends Component{
 
     state = {
-        expandSymbol: ">"
+        expandSymbol: ">",
+        sortOrder: 'down',
     }
+
+    cookies = new Cookies();
 
     componentDidMount = () => {
         this.props.search();
     }
 
-    search = (ascending) => {
-        this.props.setSortAscending(ascending);
-        let queryWithSortOrder = addSortOrder(this.props.searchString, ascending);
-        this.props.setSearchString(queryWithSortOrder);
+    search = (sortOrder) => {
+        this.setState({sortOrder: sortOrder}, () => this.props.setSortOrder(this.state.sortOrder));
+        // Set the cookie with a long maxAge. For each new search the expiration date of the
+        // cookie will be updated, so specifying an exact date may not be meaningful.
+        this.cookies.set('searchString', searchParamsToQueryString(this.props.searchParams), {path: '/', maxAge: '100000000'});
         this.props.search();
     }
 
-    submit = (event) => {
+    submit = (event) => {
         event.preventDefault();
-        this.search(this.props.sortAscending);
+        this.search(this.state.sortOrder);
     }
 
     setSearchString = (event) => {
-        this.props.setSearchString(event.target.value, false);
+        let searchParams = queryStringToSearchParameters(event.target.value);
+        this.props.setSearchParams(searchParams);
     }
 
     popover = (
@@ -107,11 +113,12 @@ class SearchResultList extends Component{
                         </Col>
                         <Col style={{paddingLeft: "0px"}}>
                             <Form.Control size="sm" 
-                                type="input" 
+                                type="input"
+                                disabled={this.props.showFilters}
                                 placeholder="No search string"
-                                value={this.props.searchString}
                                 style={{fontSize: "12px"}}
-                                onChange={this.setSearchString}> 
+                                defaultValue={searchParamsToQueryString(this.props.searchParams)}
+                                onChange={(e) => this.setSearchString(e)}>
                             </Form.Control>
                         </Col>
                         <Col style={{flexGrow: "0",paddingTop: "7px"}}>
@@ -126,7 +133,7 @@ class SearchResultList extends Component{
                                 placement="bottom">
                                     <Button 
                                         size="sm"
-                                        onClick={(e) => this.search(false)}>
+                                        onClick={(e) => this.search('down')}>
                                         <FaArrowDown/>
                                     </Button>
                             </OverlayTrigger>
@@ -140,7 +147,7 @@ class SearchResultList extends Component{
                                     placement="bottom">
                                     <Button 
                                         size="sm"
-                                        onClick={(e) => this.search(true)}>
+                                        onClick={(e) => this.search('up')}>
                                         <FaArrowUp/>
                                     </Button>
                             </OverlayTrigger>

--- a/src/customization.js
+++ b/src/customization.js
@@ -37,5 +37,10 @@ export default {
     /**
      * Specifies whether to support grouping of log entries.
      */
-    log_entry_groups_support: true
+    log_entry_groups_support: true,
+
+    /**
+     * Default search params
+     */
+    defaultSearchParams: {start: "12 hours", end: "now"}
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,65 +22,6 @@ import { v4 as uuidv4 } from 'uuid';
  const shortDateFormat = 'YYYY-MM-DD';
  const fullDateTime = 'YYYY-MM-DD HH:mm:ss';
 
- function constructLogbooksString(logbooks){ 
-     if(!logbooks || logbooks.length === 0){
-         return "";
-     }
-     var logbooksString = "logbooks=";
-     for(var i = 0; i < logbooks.length - 1; i++){
-         logbooksString += logbooks[i];
-         logbooksString += ",";
-     }
-     logbooksString += logbooks[logbooks.length - 1];
-     return logbooksString;
- }
-
- function constructTagsString(tags){ 
-    if(!tags || tags.length === 0){
-        return "";
-    }
-    var tagsString = "&tags=";
-    for(var i = 0; i < tags.length - 1; i++){
-        tagsString += tags[i];
-        tagsString += ",";
-    }
-    tagsString += tags[tags.length - 1];
-    return tagsString;
-}
-
-function getTitleSearchString(searchCriteria){
-     if(searchCriteria.title && searchCriteria.title !== ""){
-         return "&title=" + searchCriteria.title;
-     }
-     return "";
-}
-
-function getTextSearchString(searchCriteria){
-    if(searchCriteria.text && searchCriteria.text !== ""){
-        return "&desc=" + searchCriteria.text;
-    }
-    return "";
-}
-
-function getLevelSearchString(searchCriteria){
-    if(searchCriteria.level && searchCriteria.level !== ""){
-        return "&level=" + searchCriteria.level;
-    }
-    return "";
-}
-
-function getAuthorSearchString(searchCriteria){
-    if(searchCriteria.owner && searchCriteria.owner !== ""){
-        return "&owner=" + searchCriteria.owner;
-    }
-    return "";
-}
-
-function getTimeRangeString(searchCriteria){
-    return "&start=" + searchCriteria.startDate +
-        "&end=" + searchCriteria.endDate; 
-}
-
 export function formatShortTime(date){
     return moment(date).format(shortTimeFormat);
 }
@@ -91,16 +32,6 @@ export function formatShortDate(date){
 
 export function formatFullDateTime(date){
     return moment(date).format(fullDateTime);
-}
-
-export function getSearchString(searchCriteria){
-    return constructLogbooksString(searchCriteria.logbooks) 
-        + constructTagsString(searchCriteria.tags)
-        + getTimeRangeString(searchCriteria)
-        + getTitleSearchString(searchCriteria)
-        + getTextSearchString(searchCriteria)
-        + getLevelSearchString(searchCriteria)
-        + getAuthorSearchString(searchCriteria);
 }
 
 /**
@@ -223,11 +154,12 @@ export function findLogEntryGroup(tree, logEntryGroupId){
 }
 
 /**
- * Courtesy Matthew Daniels: https://gist.github.com/MatthewDaniels/388fa1e0c02613f103f00a504ed58c55
+ * Courtesy Matthew Daniels: https://gist.github.com/MatthewDaniels/388fa1e0c02613f103f00a504ed58c55.
+ * Constructs a map of search parameters from the specified query string.
  * @param {*} query 
  * @returns 
  */
-export function getQueryMap(query) {
+export function queryStringToSearchParameters(query) {
     if(typeof query !== 'string') {
        return null;
     }
@@ -254,16 +186,36 @@ export function getQueryMap(query) {
   return map;
 }
 
-export function addSortOrder(query, sortAscending){
-    let sort = sortAscending ? 'sort=up' : 'sort=down';
-    if(!query){
-        return sort;
-    }
+/**
+ * Sets or updates a search parameter
+ */
+export function setSearchParam(searchParams, key, value){
+    removeSearchParam(key);
+    searchParams[key] = value;
+    return searchParams;
+}
 
-    let map = getQueryMap(query);
-    delete map['sort'];
+/**
+ * Removes a search parameter, e.g. if user specifies an empty value.
+ */
+export function removeSearchParam(searchParams, key){
+    delete searchParams[key];
+    return searchParams;
+}
 
-    let queryString = Object.keys(map).map(key => key + '=' + map[key]).join('&');
+/**
+ * Constructs a query string from the search parameter map.
+ */
+export function searchParamsToQueryString(map){
+    return Object.keys(map).map(key => key + '=' + map[key]).join('&');
+}
 
-    return queryString + "&" + sort;
+/**
+ * Converts a JavaScript Date object to a string on format yyyy-MM-dd HH:mm:ss.
+ */
+export function dateToString(value){
+    return value.getFullYear() + '-' + ('0' + (value.getMonth() + 1)).slice(-2) + '-' +
+           ("0" + value.getDate()).slice(-2) + ' ' + ('0' + value.getHours()).slice(-2) +
+           ':' + ('0' + value.getMinutes()).slice(-2) + ':' +
+           ('0' + value.getSeconds()).slice(-2);
 }

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -16,56 +16,16 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 import {formatShortDate, 
-    getSearchString, 
     sortSearchResultByDay, 
     removeImageMarkup, 
     getLogEntryGroupId, 
     sortLogsDateCreated,
-    getQueryMap,
-    addSortOrder} from './utils';
+    queryStringToSearchParameters,
+    setSearchParam,
+    removeSearchParam,
+    dateToString,
+    searchParamsToQueryString} from './utils';
 import moment from 'moment';
-
-test('getSearchString owner', () => {
-    let searchCriteria = {owner: "owner"};
-    expect(getSearchString(searchCriteria)).toContain('owner=owner');
-});
-
-test('getSearchString title', () => {
-    let searchCriteria = {title: "title"};
-    expect(getSearchString(searchCriteria)).toContain('title=title');
-});
-
-test('getSearchString text', () => {
-    let searchCriteria = {text: "text"};
-    expect(getSearchString(searchCriteria)).toContain('desc=text');
-});
-
-test('getSearchString level', () => {
-    let searchCriteria = {level: "level"};
-    expect(getSearchString(searchCriteria)).toContain('level=level');
-    
-});
-
-test('getSearchString logbooks', () => {
-    let searchCriteria = {logbooks: ["logbook1", "logbook2"]};
-    expect(getSearchString(searchCriteria)).toContain('logbooks=logbook1,logbook2');
-});
-
-test('getSearchString tags', () => {
-    let searchCriteria = {tags: ["tag1", "tag2"]};
-    expect(getSearchString(searchCriteria)).toContain('tags=tag1,tag2');
-});
-
-test('getSearchString default time tange', () => {
-    let searchCriteria = {};
-    expect(getSearchString(searchCriteria)).toContain('start=');
-    expect(getSearchString(searchCriteria)).toContain('end=');
-});
-
-test('getSearchString time tange', () => {
-    let searchCriteria = {startDate: '1 hour', endDate: 'now'};
-    expect(getSearchString(searchCriteria)).toContain('start=1 hour&end=now');
-});
 
 test('sortSearchResultByDay', () => {
     let searchResult = [];
@@ -247,29 +207,42 @@ test('getLogEntryGroupMissing', () => {
     expect(result).toBeNull();
 });
 
-test('getQueryMap', () => {
+test('queryStringToSearchParameters', () => {
     let query = "a=b&C=D";
-    let map = getQueryMap(query);
+    let map = queryStringToSearchParameters(query);
 
     expect(map['a']).toBe('b');
 });
 
-test('addSortOrder', () => {
+test('setSearchParam', () => {
+    let map = [];
+    map['a'] = 'A';
 
-    let query = null;
-    let queryWithSortOrder = addSortOrder(query, true);
-    expect(queryWithSortOrder).toBe('sort=up');
-    queryWithSortOrder = addSortOrder(query, false);
-    expect(queryWithSortOrder).toBe('sort=down');
+    map = setSearchParam(map, 'sort', 'up');
+    let query = searchParamsToQueryString(map);
+    expect(query).toBe('a=A&sort=up');
 
-    query = "a=b&C=D";
-    queryWithSortOrder = addSortOrder(query, true);
-    expect(queryWithSortOrder).toBe('a=b&C=D&sort=up');
-    queryWithSortOrder = addSortOrder(query, false);
-    expect(queryWithSortOrder).toBe('a=b&C=D&sort=down');
+    map = [];
+    map['a'] = 'A';
+    map['sort'] = 'up';
 
-    query = "a=b&sort=up&C=D";
-    queryWithSortOrder = addSortOrder(query, false);
-    expect(queryWithSortOrder).toBe('a=b&C=D&sort=down');
-
+    map = setSearchParam(map, 'sort', 'down');
+    query = searchParamsToQueryString(map);
+    expect(query).toBe('a=A&sort=down');
 });
+
+test('removeSearchParam', () => {
+    let map = [];
+    map['a'] = 'A';
+    map['sort'] = 'up';
+
+    map = removeSearchParam(map, 'sort');
+    let query = searchParamsToQueryString(map);
+    expect(query).toBe('a=A');
+});
+
+test('dateToString', () => {
+    let now = new Date();
+    let string = dateToString(now);
+    expect(string.length).toBe(19);
+})


### PR DESCRIPTION
Highlights:

1. By default the search query editor (aka advanced search) is hidden. It can be expanded/collapsed using the dedicated button.
2. When search query editor is expanded, the query text field turn to read-only.
3. Layout in the search query editor have been updated to reflect the UI in the Phoebus client.
4. Internal business logic has been updated to make use of a "global" search parameter map.
5. When user edits a text field in the query editor to remove the value (=empty string), that search parameter is removed completely, i.e. it will not propagate to the service when executing the search. 
6. customization.js now defines a default search parameter map instead of a search string.