### PR TITLE
Adding client info HTTP header for logging on service

### DIFF
--- a/src/EntryEditor.js
+++ b/src/EntryEditor.js
@@ -35,7 +35,7 @@ import PropertyEditor from './PropertyEditor';
 import PropertySelector from './PropertySelector';
 import Selection from './Selection';
 import checkSession from './session-check';
-import { getLogEntryGroupId, newLogEntryGroup, removeImageMarkup } from './utils';
+import { getLogEntryGroupId, newLogEntryGroup, removeImageMarkup, getClientInfo } from './utils';
 import HtmlPreview from './HtmlPreview';
 import LoadingOverlay from 'react-loading-overlay';
 
@@ -260,7 +260,7 @@ class EntryEditor extends Component{
                             level: this.state.level,
                             description: this.descriptionRef.current.value
                         }
-                        axios.put(`${process.env.REACT_APP_BASE_URL}/logs?markup=commonmark`, logEntry, { withCredentials: true })
+                        axios.put(`${process.env.REACT_APP_BASE_URL}/logs?markup=commonmark`, logEntry, { withCredentials: true, headers: {"X-Olog-Client-Info": getClientInfo()}})
                             .then(res => {
                                 if(this.state.attachedFiles.length > 0){ // No need to call backend if there are no attachments.
                                     this.submitAttachmentsMulti(res.data.id);

--- a/src/MainApp.js
+++ b/src/MainApp.js
@@ -25,7 +25,7 @@ import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Collapse from 'react-bootstrap/Collapse';
 import customization from './customization';
-import {queryStringToSearchParameters, searchParamsToQueryString} from './utils.js';
+import {queryStringToSearchParameters, searchParamsToQueryString, getClientInfo} from './utils.js';
 import Cookies from 'universal-cookie';
 
 
@@ -80,7 +80,7 @@ class MainApp extends Component {
       this.cookies.set('searchString', query, {path: '/', maxAge: '100000000'});
       // Append sort, from and size
       query += "&sort=" + sortOrder + "&from=" + from + "&size=" + size;
-      fetch(`${process.env.REACT_APP_BASE_URL}/logs/search?` + query)
+      fetch(`${process.env.REACT_APP_BASE_URL}/logs/search?` + query, {headers: {"X-Olog-Client-Info": getClientInfo()}})
             .then(response => {if(response.ok){return response.json();} else {return []}})
             .then(data => {
               this.setState({searchResult: data, searchInProgress: false}, () => callback());

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,6 +17,7 @@
  */
 import moment from 'moment';
 import { v4 as uuidv4 } from 'uuid';
+import packageInfo from '../package.json';
 
  const shortTimeFormat = 'HH:mm';
  const shortDateFormat = 'YYYY-MM-DD';
@@ -226,4 +227,8 @@ export function dateToString(value){
            ("0" + value.getDate()).slice(-2) + ' ' + ('0' + value.getHours()).slice(-2) +
            ':' + ('0' + value.getMinutes()).slice(-2) + ':' +
            ('0' + value.getSeconds()).slice(-2);
+}
+
+export function getClientInfo(){
+    return "Olog Web " + packageInfo.version + " on " + window.navigator.userAgent;
 }


### PR DESCRIPTION
To get an idea of how the service is used with respect to clients (web, Phoebus), a custom HTTP header will be added for calls to create a log entry, and calls to search.

For the service to log the request it needs to be built against commit 0e7d47ed991457ae2cd8a37890060ffb73e08cfd or newer, see https://github.com/Olog/phoebus-olog/commit/0e7d47ed991457ae2cd8a37890060ffb73e08cfd.