### PR TITLE
Handle "bad request" if time range is invalid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Olog",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "dependencies": {
     "axios": "^0.21.2",

--- a/src/LoginDialog.js
+++ b/src/LoginDialog.js
@@ -53,7 +53,7 @@ class LoginDialog extends Component{
             this.hideLogin();
            }, error => { 
              if(!error.response){
-              this.setState({loginError: "Login failed. Service off-line?"})
+              this.setState({loginError: "Login failed. Unable to connect to service."})
              }
              else if(error.response.status === 401){
               this.setState({loginError: "Login failed, invalid credentials."})

--- a/src/LogoutDialog.js
+++ b/src/LogoutDialog.js
@@ -45,22 +45,9 @@ class LogoutDialog extends Component{
             this.hideLogout();
           }, error => { 
             if(!error.response){
-              this.setState({loginError: "Logout failed. Service off-line?"})
+              this.setState({loginError: "Logout failed. Unable to connect to service."})
             }
         });
-    
-        // Switch to axios?
-        /*
-        fetch(`${process.env.REACT_APP_BASE_URL}/Olog/logout`)
-        .then(response => {
-            this.setState({logoutError: ""});
-            this.props.setUserData({userName: "", roles: []});
-            this.hideLogout();
-          })
-        .catch(error => {
-          this.setState({logoutError: "Logout failed. Service off-line?"});
-        })
-        */
     }
 
     render(){

--- a/src/MainApp.js
+++ b/src/MainApp.js
@@ -81,11 +81,26 @@ class MainApp extends Component {
       // Append sort, from and size
       query += "&sort=" + sortOrder + "&from=" + from + "&size=" + size;
       fetch(`${process.env.REACT_APP_BASE_URL}/logs/search?` + query, {headers: ologClientInfoHeader()})
-            .then(response => {if(response.ok){return response.json();} else {return []}})
-            .then(data => {
-              this.setState({searchResult: data, searchInProgress: false}, () => callback());
+            .then(response => {
+              if(response.ok){
+                return response.json();
+              } 
+              else if(response.status === 400){
+                alert("Server returned 'Bad Request'.")
+              }
             })
-            .catch(() => {this.setState({searchInProgress: false}); alert("Olog service off-line?");})
+            .then(data => {
+              if(!data){
+                this.setState({searchInProgress: false});
+              }
+              else{
+                this.setState({searchResult: data, searchInProgress: false}, () => callback());
+              }
+            })
+            .catch(() => {
+              this.setState({searchInProgress: false}); 
+              alert("Unable to connect to service.");
+            });
     }
 
     setCurrentLogEntry = (logEntry) => {

--- a/src/SearchResultList.js
+++ b/src/SearchResultList.js
@@ -59,6 +59,10 @@ class SearchResultList extends Component{
     }
 
     updatePaginationControls = () => {
+        if(!this.props.searchResult){
+            this.setState({pageCount: 0});
+            return;
+        }
         // Calculate page count
         let newPageCount = Math.ceil(this.props.searchResult.hitCount / this.state.pageSize);
         
@@ -150,7 +154,7 @@ class SearchResultList extends Component{
 
     render(){
 
-        var list = this.props.searchResult.logs.map((item, index) => {
+        var list = this.props.searchResult.logs.length === 0 ? "No search results" : this.props.searchResult.logs.map((item, index) => {
             return <SearchResultItem
                         key={index}
                         log={item}
@@ -227,11 +231,11 @@ class SearchResultList extends Component{
                           '& svg circle': {stroke: 'rgba(19, 68, 83, 0.9) !important'}
                         })
                       }}>
-                    <div style={{overflowY: 'scroll', height: 'calc(80vh)'}} >
-                        {this.props.searchResult.logs.length > 0 ?
-                            list :
-                            "No search results"}
+
+                    <div style={{overflowY: 'scroll', height: 'calc(80vh)'}}>
+                        {list}
                     </div>
+                   
                     <div className="pagination-container">
                         <Container>
                            <Row>


### PR DESCRIPTION
Recent updates to Olog service will return a HTTP 400 /bad request) response if user specified time range is invalid, e.g. "start" after "end". Before the update, the service would ignore the time range and - if no other search parameters were specified - match all log entries in the index.

To correctly handle the HTTP 400 status, a few changes have been made to the web client. More specifically, an alert is shown, and the search result list is not updated.