### PR TITLE
CSSTUDIO-1694: navigation buttons should navigate search results

### DIFF
--- a/src/components/LogDetails/LogDetails.js
+++ b/src/components/LogDetails/LogDetails.js
@@ -37,7 +37,14 @@ import NavigationButtons from './NavigationButtons';
  * present. Other types of attachments are rendered as links.
  */
 // class LogDetails extends Component{
-const LogDetails = ({showGroup, setShowGroup, currentLogEntry, setCurrentLogEntry, logGroupRecords, setLogGroupRecords, userData, setReplyAction}) => {
+const LogDetails = ({
+    showGroup, setShowGroup, 
+    currentLogEntry, setCurrentLogEntry, 
+    logGroupRecords, setLogGroupRecords, 
+    userData, 
+    setReplyAction,
+    searchResults
+}) => {
 
     const remarkable = useMemo(() => new Remarkable('full', {
         html:         false,        // Enable HTML tags in source
@@ -64,8 +71,10 @@ const LogDetails = ({showGroup, setShowGroup, currentLogEntry, setCurrentLogEntr
         or if the route is of the type /logs/:id */}
         {currentLogEntry &&
             <Container className="grid-item full-height">
-                <NavigationButtons selectedLogEntryId={currentLogEntry.id}
-                    setCurrentLogEntry={setCurrentLogEntry}/>
+                <NavigationButtons {...{
+                    currentLogEntry, setCurrentLogEntry,
+                    searchResults
+                }}/>
                 {/* Site may choose to not support log entry groups */}
                 {customization.log_entry_groups_support && 
                     <Link to="/edit">

--- a/src/components/LogDetails/NavigationButtons.js
+++ b/src/components/LogDetails/NavigationButtons.js
@@ -15,60 +15,87 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
-import React, { Component } from 'react';
+import React, { useState, useEffect } from 'react';
 import Button from 'react-bootstrap/Button';
-import { withRouter } from 'react-router-dom';
 import { FaArrowRight, FaArrowLeft } from "react-icons/fa";
 import Tooltip from 'react-bootstrap/Tooltip';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
-import ologService from '../../api/olog-service';
+import { useHistory } from 'react-router-dom/cjs/react-router-dom.min';
 
-class NavigationButtons extends Component {
+const NavigationButtons = ({
+    currentLogEntry, setCurrentLogEntry,
+    searchResults
+}) => { 
 
-    step = (amount) => {
-        const {history} = this.props;
-        let id = this.props.selectedLogEntryId + amount;
-        
-        ologService.get(`/logs/${id}`)
-            .then(res => {
-                history.push('/logs/' + res.data.id);
-                this.props.setCurrentLogEntry(res.data);
+    const history = useHistory();
+    const [previousLogEntry, setPreviousLogEntry] = useState();
+    const [nextLogEntry, setNextLogEntry] = useState();
+
+    const navigateToLogEntry = (logEntry) => {
+        if(logEntry) {
+            setCurrentLogEntry(logEntry);
+            history.push('/logs/' + logEntry.id);
+        }
+    };
+
+    useEffect(() => {
+        console.log({
+            currentLogEntry, searchResults, previousLogEntry, nextLogEntry
+        })
+    })
+
+    useEffect(() => {
+        // Get the index of the current log entry; note findIndex returns -1 if no result
+        // This should only happen when navigating to a log entry directly, without searching first
+        // todo: clear search results if navigating directly
+        const currentIndex = searchResults?.logs?.findIndex(item => item.id === currentLogEntry.id);
+        if(currentIndex >= 0) {
+            console.log({
+                currentIndex, 
+                prev: searchResults.logs[currentIndex - 1],
+                next: searchResults.logs[currentIndex + 1]
             })
-            .catch(err => {
-                if(err.response && err.response.status === 404) {
-                    alert("Unable to step further.");
-                }
-                console.error("Failed to fetch log entry.", err);
-            })
-    }
+            setPreviousLogEntry(searchResults.logs[currentIndex - 1]);
+            setNextLogEntry(searchResults.logs[currentIndex + 1]);
+        }
+    }, [currentLogEntry, searchResults]);
 
-    render (){
-        return (
-            <>
-                <OverlayTrigger delay={{ hide: 450, show: 300 }}
-                     overlay={(props) => (
-                        <Tooltip {...props}>Previous log entry</Tooltip>
-                    )}
-                    rootClose
-                    placement="bottom">
-                    <Button size="sm" 
-                        style={{marginTop: "10px", marginRight: "5px"}}
-                        onClick={() => this.step(-1)}><FaArrowLeft/></Button>
-                </OverlayTrigger>
-                <OverlayTrigger delay={{ hide: 450, show: 300 }}
-                     overlay={(props) => (
-                        <Tooltip {...props}>Next log entry</Tooltip>
-                    )}
-                    rootClose
-                    placement="bottom">
-                    <Button size="sm" 
-                        style={{marginTop: "10px", marginRight: "10px"}}
-                        onClick={() => this.step(1)}><FaArrowRight/></Button>
-                </OverlayTrigger>
-            </>
-        )
-    }
+    return (
+        <>
+            <OverlayTrigger delay={{ hide: 450, show: 300 }}
+                    overlay={(props) => (
+                    <Tooltip {...props}>Previous log entry</Tooltip>
+                )}
+                rootClose
+                placement="bottom">
+                <Button 
+                    size="sm" 
+                    style={{marginTop: "10px", marginRight: "5px"}}
+                    disabled={!previousLogEntry}
+                    onClick={() => navigateToLogEntry(previousLogEntry)}
+                >
+                    <FaArrowLeft/>
+                </Button>
+            </OverlayTrigger>
+            <OverlayTrigger delay={{ hide: 450, show: 300 }}
+                    overlay={(props) => (
+                    <Tooltip {...props}>Next log entry</Tooltip>
+                )}
+                rootClose
+                placement="bottom">
+                <Button 
+                    size="sm" 
+                    style={{marginTop: "10px", marginRight: "10px"}}
+                    disabled={!nextLogEntry}
+                    onClick={() => navigateToLogEntry(nextLogEntry)}
+                >
+                    <FaArrowRight/>
+                </Button>
+            </OverlayTrigger>
+        </>
+    )
+
 }
 
-export default withRouter(NavigationButtons);
+export default NavigationButtons;
 

--- a/src/components/LogEntriesView/LogEntriesView.js
+++ b/src/components/LogEntriesView/LogEntriesView.js
@@ -75,6 +75,7 @@ const LogEntriesView = ({
             .then(res => {
                 if(res.data){
                     setSearchResults(res.data);
+                    setCurrentLogEntry(res.data.logs[0]);
                 }
             })
             .catch(err => {
@@ -171,7 +172,8 @@ const LogEntriesView = ({
                     currentLogEntry, setCurrentLogEntry, 
                     logGroupRecords, setLogGroupRecords, 
                     userData, 
-                    setReplyAction
+                    setReplyAction,
+                    searchResults
                 }}/>
             );
         } else {


### PR DESCRIPTION
Currently, the navigation buttons in the LogDetails view navigate incrementally/decrementally by id rather than over the search results, and it throws a popup when no more data is available.

What it should happen instead is:

- the buttons navigate forwards/backwards through the search results
- when there is no data in a direction, then the button grays out / disables instead of throwing a popup
- when going into the next page of results, the search results view should update to show that page
- whatever result is being shown should be 'active' / colored like when you click on a search result item directly
