### PR TITLE
CSSTUDIO-1780: Pagination controls render outside container on some widths

### DIFF
--- a/src/components/SearchResult/PaginationBar.js
+++ b/src/components/SearchResult/PaginationBar.js
@@ -51,8 +51,9 @@ const PaginationBar = ({pageCount, currentPageIndex, goToPage, searchPageParams,
     return (
         <Container fluid className="py-2" >
             <Row className="p-2">
-                <Col className="d-flex align-items-center justify-content-between p-0 pr-1" >
-                    <Col className="d-flex align-items-center p-0 pr-1" xs='auto' >
+                <Col className="
+                    d-flex flex-row flex-lg-column align-items-center justify-content-between p-0 pr-1" >
+                    <Col className="d-flex align-items-center p-0 pr-1 mb-lg-2" xs='auto' >
                         <Form.Label className="inline-block align-middle m-0 mr-2 text-nowrap" >Hits per page:</Form.Label> 
                         <Col style={{padding: '0px', maxWidth: '40px'}}>
                             <Form.Control size="sm" 
@@ -63,7 +64,9 @@ const PaginationBar = ({pageCount, currentPageIndex, goToPage, searchPageParams,
                                 />
                         </Col>
                     </Col>
-                    <Col sm={'auto'} style={{visibility: pageCount < 2 ? 'hidden' : 'visible'}} className="d-flex align-items-center justify-content-end px-0">
+                    <Col sm={'auto'} className={`
+                        ${pageCount < 2 ? 'd-none' : 'd-flex'} align-items-center justify-content-end px-0`
+                    }>
                         <Pagination size='sm' className="m-0"> 
                             <Pagination.Prev  onClick={() => goToPage(currentPageIndex - 1)} 
                                 disabled={currentPageIndex === 0}


### PR DESCRIPTION
solution: show pagination control on separate line on large devices, and hide when only one page of results (e.g. eliminate the media-query problem altogether except for the existing case on small devices)