### PR TITLE
CSSSTUDIO-1816: markdown list elements not indented

### DIFF
--- a/src/components/shared/HtmlContent.js
+++ b/src/components/shared/HtmlContent.js
@@ -47,6 +47,10 @@ const Container = styled.div`
     ol {
         list-style: decimal inside;
     }
+    li > ul,
+    li > ol {
+        padding-left: 2rem;
+    }
 
     /** Code **/
     code, pre {


### PR DESCRIPTION
Note that indented items require 4 spaces (not 2)

**Requires visual inspection**

Test Markdown: 

```
Favorite Things:

* flowers
    * roses
        * red roses
            * with thorns
            * smooth stem
        * white roses
    * tulips
* birds
    * parrots
        * cockatiels
            * pied coloration
            * normal coloration
        * budgies
            * blue and white
            * yellow and green
            * solid color
    * toucans
* bees
    * bumbly ones
        * big buzzers
        * little buzzers
    * stingy ones

Stuff to do:

1. Bake Cookies
    1. Mix the wet
        1. cream the butter and sugar
    1. Mix the dry
    1. Bake in the oven
2. Hug Friends
3. Conquer the shadow realm
```