### PR TITLE
CSSTUDIO-1831: Add Formatting Link to Description

### DIFF
--- a/src/api/olog-service.js
+++ b/src/api/olog-service.js
@@ -17,12 +17,11 @@
  */
 
 import axios from "axios";
-
-const ologServiceBaseUrl = process.env.REACT_APP_BASE_URL; // e.g. http://localhost:8080/Olog
+import { APP_BASE_URL } from "constants";
 
 // Need axios for back-end access as the "fetch" API does not support CORS cookies.
 const ologService = axios.create({
-    baseURL: ologServiceBaseUrl
+    baseURL: APP_BASE_URL
 });
 
 /**

--- a/src/components/EntryEditor/index.js
+++ b/src/components/EntryEditor/index.js
@@ -18,7 +18,7 @@
 import ologService, { ologServiceWithRetry } from 'api/olog-service';
 import Button from '../shared/Button';
 import Modal, {Header, Title, Body} from 'components/shared/Modal';
-import { FaPlus } from 'react-icons/fa';
+import { FaMarkdown, FaPlus } from 'react-icons/fa';
 import { useNavigate } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import Attachment from 'components/Attachment';
@@ -41,6 +41,8 @@ import useFormPersist from 'react-hook-form-persist'
 import TextInput from 'components/shared/input/TextInput';
 import styled from 'styled-components';
 import { DroppableFileUploadInput } from 'components/shared/input/FileInput';
+import ExternalLink from 'components/shared/ExternalLink';
+import { APP_BASE_URL } from 'constants';
 
 const Container = styled.div`
     padding: 0.5rem;
@@ -69,7 +71,14 @@ const DescriptionTextInput = styled(TextInput)`
 
 const DescriptionContainerFooter = styled.div`
     display: flex;
-    gap: 1rem;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 0.5rem;
+
+    & div {
+        display: flex;
+        gap: 1rem;
+    }
 `
 
 const ButtonContent = styled.div`
@@ -425,22 +434,29 @@ const EntryEditor = ({
                                 rows={10}
                             />
                             <DescriptionContainerFooter>
-                                <Button variant="secondary" size="sm" style={{marginLeft: "5px"}}
-                                        onClick={(e) => {
-                                            e.preventDefault();
-                                            e.stopPropagation();
-                                            setShowEmbedImageDialog(true);
-                                        }}>
-                                    Embed Image
-                                </Button>
-                                <Button variant="secondary" size="sm" style={{marginLeft: "5px"}}
-                                        onClick={(e) => {
-                                            e.preventDefault();
-                                            e.stopPropagation();
-                                            setShowHtmlPreview(true)
-                                        }}>
-                                    Preview
-                                </Button>
+                                <div>
+                                    <ExternalLink href={`${APP_BASE_URL}/help/CommonmarkCheatsheet`} >
+                                        <FaMarkdown />CommonMark Formatting Help
+                                    </ExternalLink>
+                                </div>
+                                <div>
+                                    <Button variant="secondary" size="sm" style={{marginLeft: "5px"}}
+                                            onClick={(e) => {
+                                                e.preventDefault();
+                                                e.stopPropagation();
+                                                setShowEmbedImageDialog(true);
+                                            }}>
+                                        Embed Image
+                                    </Button>
+                                    <Button variant="secondary" size="sm" style={{marginLeft: "5px"}}
+                                            onClick={(e) => {
+                                                e.preventDefault();
+                                                e.stopPropagation();
+                                                setShowHtmlPreview(true)
+                                            }}>
+                                        Preview
+                                    </Button>
+                                </div>
                             </DescriptionContainerFooter>
                         </DescriptionContainer>
                         <DetachedLabel>Attachments</DetachedLabel>

--- a/src/components/shared/ExternalLink.js
+++ b/src/components/shared/ExternalLink.js
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+
+const StyledExternalLink = styled.a`
+    display: flex;
+    gap: 0.25rem;
+    align-items: center;
+
+    &, & > * {
+        color: ${({theme}) => theme.colors.primary} !important;
+        font-style: italic;
+        text-decoration: underline;
+    }
+`
+
+const ExternalLink = ({href, children}) => {
+    return <StyledExternalLink href={href} rel="noopener noreferrer" target='_blank' >{children}</StyledExternalLink>
+}
+
+export default ExternalLink;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,1 @@
+export const APP_BASE_URL = process.env.REACT_APP_BASE_URL; // e.g. http://localhost:8080/Olog


### PR DESCRIPTION
feature: help link for description commonmark formatting. 
refactor: make app url available as a constant

UX note: since the help link is a secondary action it is on the bottom left, and the other primary-action buttons (embed image, preview) are on the bottom right.