### PR TITLE
CSSTUDIO-1837: Olog web client group view incorrect styling

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@
 - [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
     - [ ] ...when viewing a log entry
     - [ ] ...when previewing HTML while writing a description
+    - [ ] ...when viewing a log entry in the group view
 - [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
     - [ ] ...search result list
     - [ ] ...log entry group view list

--- a/src/components/LogDetails/LogEntryGroupView.js
+++ b/src/components/LogDetails/LogEntryGroupView.js
@@ -24,6 +24,7 @@ import {getLogEntryGroupId, sortLogsDateCreated} from 'utils';
 import GroupHeader from './GroupHeader';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
+import HtmlContent from 'components/shared/HtmlContent';
 
 const Container = styled.div`
     display: flex;
@@ -45,8 +46,8 @@ const GroupContainer = styled.li`
     }
 `
 
-const Content = styled.div`
-    word-wrap: break-word;
+const StyledHtmlContent = styled(HtmlContent)`
+    padding: 0 0.5rem;
 `
 
  /**
@@ -84,7 +85,7 @@ const LogEntryGroupView = ({remarkable, currentLogEntry, logGroupRecords, setLog
         return(
             <GroupContainer key={index} onClick={() => showLog(row)} >
                 <GroupHeader logEntry={row} />
-                <Content dangerouslySetInnerHTML={getContent(row.source)}/>
+                <StyledHtmlContent html={getContent(row.source)}/>
             </GroupContainer>
         );
     });


### PR DESCRIPTION
## Summary of Changes
fix: group view of log entry not styling markdown

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [x] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [x] ...when viewing a log entry
    - [x] ...when previewing HTML while writing a description
    - [x] ...when viewing a log entry in the group view
- [x] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [x] ...search result list
    - [x] ...log entry group view list
    - [x] ...log entry single view
    - [x] ...create new log entry page
- [x] Overall layout fills full width and height of viewport
- [x] Pagination element doesn't overflow into other elements
