### PR TITLE
CSSTUDIO-1840: Need to handle "hits per page" being empty

### DIFF
--- a/src/api/olog-service.js
+++ b/src/api/olog-service.js
@@ -18,24 +18,12 @@
 
 import axios from "axios";
 import { APP_BASE_URL } from "constants";
+import { delay } from "utils";
 
 // Need axios for back-end access as the "fetch" API does not support CORS cookies.
 const ologService = axios.create({
     baseURL: APP_BASE_URL
 });
-
-/**
- * A wrapper around setTimeout that allows awaiting a delay.
- * @param {number} duration duration in milliseconds to delay.
- * @returns a resolvable Promise.
- */
-const delay = (duration) => {
-    return new Promise((resolve) => {
-        setTimeout(() => {
-            resolve();
-        }, duration)
-    })
-}
 
 /**
  * Perform an Olog Service request with a retry policy

--- a/src/components/App.test.js
+++ b/src/components/App.test.js
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import selectEvent from 'react-select-event';
 import { MemoryRouter } from 'react-router-dom';
 import customization from 'utils/customization';
+import { delay } from 'utils';
 
 it('renders without crashing', async () => {
     const { unmount } = render(<MemoryRouter><App /></MemoryRouter>);
@@ -734,12 +735,10 @@ describe('Pagination Bar', () => {
             rest.get('*/logs/search', (req, res, ctx) => {
                 const from = req.url.searchParams.get('from');
                 const size = req.url.searchParams.get('size');
-                console.log({from, size})
+
                 if(!from || !size || `${from}`.trim() === '' || `${size}`.trim() === '') {
-                    console.log('responding with error')
                     return res(ctx.status(500));
                 } else {
-                    console.log('looks good!')
                     return res(ctx.json(resultList([testEntry({title: 'some title'})])))
                 }
 
@@ -748,7 +747,7 @@ describe('Pagination Bar', () => {
 
         // When rendered
         const user = userEvent.setup();
-        const { unmount, container } = render(
+        const { unmount } = render(
             <MemoryRouter>
                 <App />
             </MemoryRouter>
@@ -766,8 +765,6 @@ describe('Pagination Bar', () => {
     
         // The hitsPerPage input should be empty
         expect(hitsPerPage).toHaveValue('');
-
-        screen.debug(container, 100000000000);
     
         // And the previous search results should remain
         const previousSearchResults = await screen.findByRole('heading', {name: /some title/});
@@ -781,4 +778,48 @@ describe('Pagination Bar', () => {
         unmount();
     
     })
+
+    test('paging controls are shown when only when more than one page of results are available', async () => {
+    
+        const user = userEvent.setup();
+        const { unmount } = render(
+            <MemoryRouter>
+                <App />
+            </MemoryRouter>
+        );
+    
+        // Given the server responds with a page of 10 results and 11 hits 
+        server.use(
+            rest.get('*/logs/search', (req, res, ctx) => {
+                return res(ctx.json(
+                    resultList([
+                        ...[...Array(10).keys()].map(it => testEntry({title: `title #${it + 1}`, id: it+1}))
+                    ], 11)
+                ))
+
+            })
+        );
+
+        // And the user sets the page size to 10
+        const hitsPerPage = screen.getByLabelText(/hits per page/i);
+        await user.clear(hitsPerPage);
+        await user.type(hitsPerPage, '10');
+        
+        // Then the pagination controls should be rendered
+        const paginationControls = await screen.findByRole('navigation', {name: /pagination controls/i});
+        expect(paginationControls).toBeInTheDocument();
+
+        // And when the user sets the page size to 11
+        await user.clear(hitsPerPage);
+        await user.type(hitsPerPage, '11');
+
+        // Then the pagination controls should not be rendered
+        const noPaginationControls = screen.queryByRole('navigation', {name: /pagination controls/i});
+        expect(noPaginationControls).not.toBeInTheDocument();
+
+        // cleanup network resources
+        unmount();
+    
+    })
+
 })

--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -1,41 +1,39 @@
 import styled from "styled-components";
-import { StyledPaginationButton } from "./styles";
+import { StyledListItem, StyledPagination, StyledPaginationButton } from "./styles";
 import {MdNavigateNext, MdNavigateBefore} from 'react-icons/md'
 
-export const Pagination = styled.div`
-    display: flex;
-    & > * {
-        border: 1px solid ${({theme}) => theme.colors.neutral};
-    }
-    & > *:not(:first-child) {
-        border-left: none;
-    }
-`
-
-const StyledItem = styled(StyledPaginationButton)`
-    border-radius: 0;
-`
-
-export const Item = ({className, children, ...props}) => {
+export const Pagination = ({className, children}) => {
     return (
-        <StyledItem {...props} className={`pagination-item ${className ? className : ''}`} >
-            {children}
-        </StyledItem>
+        <StyledPagination className={className} aria-label='pagination controls'>
+            <ul>
+                {children}
+            </ul>
+        </StyledPagination>
+    )
+}
+
+export const PaginationItem = ({className, active, disabled, label, children, ...props}) => {
+    return (
+        <StyledListItem {...props} className={className} >
+            <StyledPaginationButton aria-current={active} aria-label={label} disabled={disabled} >
+                {children}
+            </StyledPaginationButton>
+        </StyledListItem>
     )
 }
 
 export const Prev = ({className, ...props}) => {
     return (
-        <Item {...{alt: 'Previous', ...props}}>
-            <MdNavigateBefore />
-        </Item>
+        <PaginationItem {...{className, ...props}}>
+            <MdNavigateBefore aria-label="go to previous page" />
+        </PaginationItem>
     )
 }
 
 export const Next = ({className, ...props}) => {
     return (
-        <Item {...{alt: 'Next', ...props}}>
-            <MdNavigateNext />
-        </Item>
+        <PaginationItem {...{className, ...props}} >
+            <MdNavigateNext aria-label="go to next page" />
+        </PaginationItem>
     )
 }

--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -1,4 +1,3 @@
-import styled from "styled-components";
 import { StyledListItem, StyledPagination, StyledPaginationButton } from "./styles";
 import {MdNavigateNext, MdNavigateBefore} from 'react-icons/md'
 

--- a/src/components/Pagination/styles.js
+++ b/src/components/Pagination/styles.js
@@ -1,30 +1,51 @@
 import styled from "styled-components";
 import { buttonBaseStyle } from "components/shared/Button";
 
-export const StyledPaginationButton = styled.button`
-    ${buttonBaseStyle}
-    color: ${({theme}) => theme.colors.primary};
-    background-color: ${({theme}) => theme.colors.lightest};
-    text-decoration: none;
-    width: min-content;
-    padding: 0.5rem 1rem;
-    &:visited {
-        text-decoration: none;
-        color: inherit;
+export const StyledPagination = styled.nav`
+    ul {
+        display: flex;
     }
-    &[disabled] {
-        filter: opacity(50%) grayscale(100%);
-        cursor: not-allowed;
+    ul > * {
+        border: 1px solid ${({theme}) => theme.colors.neutral};
     }
+    ul > *:not(:first-child) {
+        border-left: none;
+    }
+`
 
-    ${({active, theme}) => active ? 
-    `
-        background-color: ${theme.colors.primary};
-        color: ${theme.colors.lightest};
-    `: `
+export const StyledListItem = styled.li`
+
+    ${({theme}) => `
+        [aria-current="true"] {
+            background-color: ${theme.colors.primary};
+            color: ${theme.colors.lightest};
+        }
         &:hover[enabled] {
             background-color: ${theme.colors.light};
             filter: none;
         }
     `}
+
+`
+
+export const StyledPaginationButton = styled.button`
+
+    ${buttonBaseStyle}
+    border-radius: 0;
+    color: ${({theme}) => theme.colors.primary};
+    background-color: ${({theme}) => theme.colors.lightest};
+    text-decoration: none;
+    width: min-content;
+    padding: 0.5rem 1rem;
+
+    &:visited {
+        text-decoration: none;
+        color: inherit;
+    }
+
+    &[disabled] {
+        filter: opacity(50%) grayscale(100%);
+        cursor: not-allowed;
+    }
+
 `

--- a/src/components/SearchResult/PageSizeInput.js
+++ b/src/components/SearchResult/PageSizeInput.js
@@ -1,0 +1,36 @@
+import { StyledLabeledTextInput } from "components/shared/input/TextInput";
+import { useState } from "react";
+
+const PageSizeInput = ({initialValue=0, onValidChange=() => {}}) => {
+
+    const [pageSize, setPageSize] = useState(initialValue);
+
+    /**
+     * Handles input in hits per page field and rejets any
+     * value < 1 and > 999, i.e. leading zeros are also rejected.
+     */
+    const onPageSizeChange = (e) => {
+        const re = /^([1-9]|[1-9][0-9]{1,2})$/
+        if(e.target.value === '' || re.test(e.target.value)) {
+            setPageSize(e.target.value)
+            if(`${e.target.value}`.trim() !== '') {
+                onValidChange(e.target.value)
+            }
+        }
+    }
+
+    return (
+        <StyledLabeledTextInput
+            type='text'
+            inputMode='numeric'
+            name='pageSize'
+            label='Hits per page:'
+            value={pageSize}
+            onChange={onPageSizeChange}
+            inlineLabel
+        />
+    )
+
+}
+
+export default PageSizeInput;

--- a/src/components/SearchResult/PageSizeInput.test.js
+++ b/src/components/SearchResult/PageSizeInput.test.js
@@ -1,11 +1,11 @@
 import userEvent from '@testing-library/user-event';
 import { render, screen } from 'test-utils';
-import PaginationBar from './PaginationBar'
+import PageSizeInput from './PageSizeInput'
 
 test('hits per page accepts positive integers', async () => {
 
     const user = userEvent.setup();
-    render(<PaginationBar />)
+    render(<PageSizeInput />);
 
     const hitsPerPage = screen.getByLabelText(/hits per page/i);
     await user.clear(hitsPerPage);
@@ -18,7 +18,7 @@ test('hits per page accepts positive integers', async () => {
 test('hits per page rejects negative numbers', async () => {
 
     const user = userEvent.setup();
-    render(<PaginationBar />)
+    render(<PageSizeInput />);
 
     const hitsPerPage = screen.getByLabelText(/hits per page/i);
     await user.clear(hitsPerPage);
@@ -31,7 +31,7 @@ test('hits per page rejects negative numbers', async () => {
 test('hits per page rejects zero', async () => {
 
     const user = userEvent.setup();
-    render(<PaginationBar />)
+    render(<PageSizeInput />);
 
     const hitsPerPage = screen.getByLabelText(/hits per page/i);
     await user.clear(hitsPerPage);
@@ -44,7 +44,7 @@ test('hits per page rejects zero', async () => {
 test('hits per page rejects text', async () => {
 
     const user = userEvent.setup();
-    render(<PaginationBar />)
+    render(<PageSizeInput />);
 
     const hitsPerPage = screen.getByLabelText(/hits per page/i);
     await user.clear(hitsPerPage);
@@ -57,7 +57,7 @@ test('hits per page rejects text', async () => {
 test('hits per page rejects leading zeros', async () => {
 
     const user = userEvent.setup();
-    render(<PaginationBar />)
+    render(<PageSizeInput />);
 
     const hitsPerPage = screen.getByLabelText(/hits per page/i);
     await user.clear(hitsPerPage);
@@ -68,7 +68,7 @@ test('hits per page rejects leading zeros', async () => {
 test('hits per page rejects numbers greater than three digits', async () => {
 
     const user = userEvent.setup();
-    render(<PaginationBar />)
+    render(<PageSizeInput />);
 
     const hitsPerPage = screen.getByLabelText(/hits per page/i);
     await user.clear(hitsPerPage);

--- a/src/components/SearchResult/PaginationBar.js
+++ b/src/components/SearchResult/PaginationBar.js
@@ -18,11 +18,11 @@
 
 import { useMediaQuery } from 'react-responsive';
 import styled from 'styled-components';
-import { StyledLabeledTextInput } from 'components/shared/input/TextInput';
-import { Item, Next, Pagination, Prev } from 'components/Pagination';
+import { PaginationItem, Next, Pagination, Prev } from 'components/Pagination';
 import { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { updateSearchPageParams } from 'features/searchPageParamsReducer';
+import PageSizeInput from './PageSizeInput';
 
 const Container = styled.div`
     display: flex;
@@ -45,15 +45,12 @@ const PagePosition = styled.div`
     white-space: nowrap;
 `
 
-const PaginationBar = () => {
+const PaginationBar = ({searchResults, searchPageParams}) => {
 
     const [pageCount, setPageCount] = useState(0);
     const [currentPageIndex, setCurrentPageIndex] = useState(0);
-    const searchResults = useSelector(state => state.searchResults);
-    const searchPageParams = useSelector(state => state.searchPageParams);
-    const [pageSize, setPageSize] = useState(searchPageParams.size);
     const dispatch = useDispatch();
-
+    
     useEffect(() => {
         if(!searchResults){
             setPageCount(0);
@@ -80,20 +77,6 @@ const PaginationBar = () => {
         };
     }
 
-    /**
-     * Handles input in hits per page field and rejets any
-     * value < 1 and > 999, i.e. leading zeros are also rejected.
-     */
-    const onPageSizeChange = (e) => {
-        const re = /^([1-9]|[1-9][0-9]{1,2})$/
-        if(e.target.value === '' || re.test(e.target.value)) {
-            setPageSize(e.target.value)
-            if(`${e.target.value}`.trim() !== '') {
-                dispatch(updateSearchPageParams({...searchPageParams, size: e.target.value}))
-            }
-        }
-    }
-
     const isMobile = useMediaQuery({ query: '(max-width: 539px)' })
 
     let maxPaginationItems = 6;
@@ -111,41 +94,50 @@ const PaginationBar = () => {
 
         let items = [];
         for(let i = firstIndex; i < lastIndex; i++){
-            items.push(<Item
+            const isCurrentPage = i === currentPageIndex;
+            items.push(<PaginationItem
                 key={i} 
-                active={i === currentPageIndex}
-                onClick={() => goToPage(i)}
-                alt={`Page ${i+1}`}
+                active={isCurrentPage}
+                onClick={() => {
+                    if(!isCurrentPage) {
+                        goToPage(i)
+                    }
+                }}
+                label={`go to page ${i+1}`}
             >
                 {i + 1}
-            </Item>)
+            </PaginationItem>)
         }
         return items;
+    }
+
+    const prevDisabled = currentPageIndex === 0;
+    const nextDisabled = currentPageIndex + 1 === pageCount;
+    const onClickPreviousPage = () => {
+        if(!prevDisabled) {
+            goToPage(currentPageIndex - 1);
+        }
+    }
+    const onClickNextPage = () => {
+        if(!nextDisabled) {
+            goToPage(currentPageIndex + 1);
+        }
     }
 
     return (
         <Container>
             <PageSizeContainer>
-                <StyledLabeledTextInput
-                    type='text'
-                    inputMode='numeric'
-                    name='pageSize'
-                    label='Hits per page:'
-                    value={pageSize}
-                    onChange={onPageSizeChange}
-                    inlineLabel
+                <PageSizeInput 
+                    initialValue={searchPageParams.size}
+                    onValidChange={(value) => dispatch(updateSearchPageParams({...searchPageParams, size: value}))}
                 />
             </PageSizeContainer>
             {pageCount >= 2 ? 
                 <PaginationContainer>
                     <Pagination>
-                        <Prev onClick={() => goToPage(currentPageIndex - 1)} 
-                            disabled={currentPageIndex === 0}
-                        />
+                        <Prev onClick={onClickPreviousPage} disabled={prevDisabled} />
                         {renderPaginationItems()}
-                        <Next onClick={() => goToPage(currentPageIndex + 1)}
-                            disabled={currentPageIndex + 1 === pageCount}
-                        />
+                        <Next onClick={onClickNextPage} disabled={nextDisabled} />
                     </Pagination>
                     <PagePosition>{`${currentPageIndex + 1} / ${pageCount}`}</PagePosition>
                 </PaginationContainer>

--- a/src/components/SearchResult/PaginationBar.test.js
+++ b/src/components/SearchResult/PaginationBar.test.js
@@ -1,0 +1,79 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen } from 'test-utils';
+import PaginationBar from './PaginationBar'
+
+test('hits per page accepts positive integers', async () => {
+
+    const user = userEvent.setup();
+    render(<PaginationBar />)
+
+    const hitsPerPage = screen.getByLabelText(/hits per page/i);
+    await user.clear(hitsPerPage);
+    await user.type(hitsPerPage, '45');
+
+    expect(hitsPerPage).toHaveValue('45');
+
+})
+
+test('hits per page rejects negative numbers', async () => {
+
+    const user = userEvent.setup();
+    render(<PaginationBar />)
+
+    const hitsPerPage = screen.getByLabelText(/hits per page/i);
+    await user.clear(hitsPerPage);
+    await user.type(hitsPerPage, '-50');
+
+    expect(hitsPerPage).toHaveValue('50');
+
+})
+
+test('hits per page rejects zero', async () => {
+
+    const user = userEvent.setup();
+    render(<PaginationBar />)
+
+    const hitsPerPage = screen.getByLabelText(/hits per page/i);
+    await user.clear(hitsPerPage);
+    await user.type(hitsPerPage, '0');
+
+    expect(hitsPerPage).toHaveValue('');
+
+})
+
+test('hits per page rejects text', async () => {
+
+    const user = userEvent.setup();
+    render(<PaginationBar />)
+
+    const hitsPerPage = screen.getByLabelText(/hits per page/i);
+    await user.clear(hitsPerPage);
+    await user.type(hitsPerPage, 'the1tringofpower');
+
+    expect(hitsPerPage).toHaveValue('1');
+
+})
+
+test('hits per page rejects leading zeros', async () => {
+
+    const user = userEvent.setup();
+    render(<PaginationBar />)
+
+    const hitsPerPage = screen.getByLabelText(/hits per page/i);
+    await user.clear(hitsPerPage);
+    await user.type(hitsPerPage, '0038');
+    expect(hitsPerPage).toHaveValue('38');
+
+})
+test('hits per page rejects numbers greater than three digits', async () => {
+
+    const user = userEvent.setup();
+    render(<PaginationBar />)
+
+    const hitsPerPage = screen.getByLabelText(/hits per page/i);
+    await user.clear(hitsPerPage);
+    await user.type(hitsPerPage, '12345678');
+
+    expect(hitsPerPage).toHaveValue('123');
+
+})

--- a/src/components/shared/input/TextInput.js
+++ b/src/components/shared/input/TextInput.js
@@ -3,14 +3,14 @@ import { useController } from "react-hook-form";
 import styled from "styled-components"
 import LabeledInput from "./LabeledInput"
 
-const Input = styled.input`
+export const StyledInput = styled.input`
     width: 100%;
     padding: 0.5rem 1rem;
     border: solid 1px ${({theme}) => theme.colors.light};
     border-radius: 5px;
 `
 
-const TextArea = styled.textarea`
+export const StyledTextArea = styled.textarea`
     width: 100%;
     padding: 0.5rem 1rem;
     border: solid 1px ${({theme}) => theme.colors.light};
@@ -19,7 +19,7 @@ const TextArea = styled.textarea`
 
 export const StyledTextInput = React.forwardRef(({name, label, className, textArea=false, rows=3, password=false, value, onChange, ...props}, innerRef) => {
     return textArea ? 
-    <TextArea 
+    <StyledTextArea 
         ref={innerRef}
         name={name} 
         id={name}
@@ -30,7 +30,7 @@ export const StyledTextInput = React.forwardRef(({name, label, className, textAr
         rows={rows}
         {...props}
     />
-    : <Input 
+    : <StyledInput 
         ref={innerRef}
         type={password ? 'password' : 'text'}
         name={name} 
@@ -43,7 +43,7 @@ export const StyledTextInput = React.forwardRef(({name, label, className, textAr
     />;
 })
 
-export const StyledLabeledTextInput = React.forwardRef(({name, label, message, className, textArea=false, rows=3, password=false, value, onChange, inlineLabel, props}, innerRef) => {
+export const StyledLabeledTextInput = React.forwardRef(({name, label, message, className, textArea=false, rows=3, password=false, value, onChange, inlineLabel, ...props}, innerRef) => {
     return (
         <LabeledInput {...{name, label, error: message, inlineLabel}} >
             <StyledTextInput 

--- a/src/test-utils/index.js
+++ b/src/test-utils/index.js
@@ -67,9 +67,9 @@ export const testEntry = ({title, id, createdDate}) => (
     }
 )
 
-export const resultList = (testEntries = []) => {
+export const resultList = (testEntries = [], hitCount) => {
     return {
-        hitCount: testEntries.length,
+        hitCount: hitCount || testEntries.length,
         logs: [
             ...testEntries
         ]

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -167,3 +167,16 @@ export function dateToString(value){
 export function ologClientInfoHeader() {
     return {"X-Olog-Client-Info": "Olog Web " + packageInfo.version + " on " + window.navigator.userAgent}
 }
+
+/**
+ * A wrapper around setTimeout that allows awaiting a delay.
+ * @param {number} duration duration in milliseconds to delay.
+ * @returns a resolvable Promise.
+ */
+export const delay = (duration) => {
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            resolve();
+        }, duration)
+    })
+}


### PR DESCRIPTION
## Summary of Changes

- fix: only allow values 1-999 on page size, allow blanks but don't submit them. 
- fix: infinite looping / dependencies in pagination bar. 
- refactor: move delay utility function into utilities file.

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [x] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [x] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [x] Overall layout fills full width and height of viewport
- [x] Pagination element doesn't overflow into other elements
