### PR TITLE
CSSTUDIO-1843: Visual jittering when clicking some log entries (caused by horiz scrollbar)

### DIFF
--- a/src/components/LogDetails/LogEntryGroupView.js
+++ b/src/components/LogDetails/LogEntryGroupView.js
@@ -40,6 +40,7 @@ const GroupContainer = styled.li`
     flex-direction: column;
     gap: 0.25rem;
     cursor: pointer;
+    width: 100%;
     
     &:hover {
         background-color: rgba(0, 0, 0, 0.20); 
@@ -48,6 +49,7 @@ const GroupContainer = styled.li`
 
 const StyledHtmlContent = styled(HtmlContent)`
     padding: 0 0.5rem;
+    overflow: auto;
 `
 
  /**

--- a/src/components/LogDetails/LogEntrySingleView.js
+++ b/src/components/LogDetails/LogEntrySingleView.js
@@ -52,6 +52,7 @@ const Description = styled(HtmlContent)`
     padding-bottom: 1rem;
     wordWrap: break-word;
     font-size: 1.2rem;
+    overflow: auto;
 `
 
 const AttachmentImage = styled.img`

--- a/src/components/LogEntriesView/index.js
+++ b/src/components/LogEntriesView/index.js
@@ -29,7 +29,7 @@ import { updateCurrentLogEntry } from 'features/currentLogEntryReducer';
 import ServiceErrorBanner from 'components/ErrorBanner';
 import styled from 'styled-components';
 import Filters from 'components/Filters';
-import { mobile } from 'config/media';
+import { desktop, mobile } from 'config/media';
 
 const ContentContainer = styled.div`
     height: 100%;
@@ -72,7 +72,11 @@ const LogDetailsContainer = styled.div`
     flex: 1 0 0;
     border: 1px solid ${({theme}) => theme.colors.light};
     border-radius: 5px;
-
+    
+    ${desktop(`
+        overflow-x: hidden;
+        overflow-y: auto;
+    `)}
     ${mobile(`
         order: -1;
         width: 100%;

--- a/src/config/media.js
+++ b/src/config/media.js
@@ -1,12 +1,12 @@
 import { css } from "styled-components";
 
 const size = {
-    desktop: '2560px',
+    desktop: '1024px',
     mobile: '480px'
 }
 
 export const desktop = (content) => css`
-    @media(max-width: ${size.desktop}) {
+    @media(min-width: ${size.desktop}) {
         ${content}
     }
 `


### PR DESCRIPTION
## Summary of Changes

- style: horizontal scrollbar should only appear on log entries, not on entire app 
- fix: jittering on some screens caused by appearance of horiz scrollbar when clicking wide log entries

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [x] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [x] ...when viewing a log entry
    - [x] ...when previewing HTML while writing a description
    - [x] ...when viewing a log entry in the group view
- [x] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [x] ...search result list
    - [x] ...log entry group view list
    - [x] ...log entry single view
    - [x] ...create new log entry page
- [x] Overall layout fills full width and height of viewport
- [x] Pagination element doesn't overflow into other elements
