### PR TITLE
CSSTUDIO-1854: Shrink margin below horizontal ruler

### DIFF
--- a/src/components/shared/HtmlContent.js
+++ b/src/components/shared/HtmlContent.js
@@ -70,7 +70,6 @@ const Container = styled.div`
         border: none;
         border-top: 3px solid #E1E1E1;
         margin-top: 1rem;
-        margin-bottom: 3.5rem;
     }
 
     /** Table Styling **/


### PR DESCRIPTION
## Summary of Changes

- style: remove margin-bottom on hr markup, to match Java client style

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [x] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [x] Overall layout fills full width and height of viewport
- [x] Pagination element doesn't overflow into other elements
