### PR TITLE
Csstudio 1805: Paste Image Embed Feature

### DIFF
--- a/src/components/Attachment/index.js
+++ b/src/components/Attachment/index.js
@@ -60,7 +60,9 @@ const ImageHeader = styled.div`
     align-items: center;
 `
 
-const CloseIcon = styled(BsXCircle)`
+const CloseIcon = styled.button`
+    background-color: transparent;
+    border: none;
     &:hover {
         cursor: pointer;
     }
@@ -126,7 +128,11 @@ const Attachment = ({attachment, removeAttachment, className}) => {
     return (
         <>
             <Container className={className}>
-                <ImageHeader><CloseIcon onClick={() => removeAttachment(attachment.file)} /></ImageHeader>
+                <ImageHeader>
+                    <CloseIcon onClick={() => removeAttachment(attachment.file)} aria-label={`remove ${attachment.file.name}`}>
+                        <BsXCircle />
+                    </CloseIcon>
+                </ImageHeader>
                 <ImageContainer onClick={previewImage} >
                     {image}
                 </ImageContainer>

--- a/src/components/EntryEditor/EmbedImageDialog.js
+++ b/src/components/EntryEditor/EmbedImageDialog.js
@@ -20,7 +20,7 @@ import React, { useEffect } from 'react';
 import Modal, {Header, Title, Body, Footer} from '../shared/Modal';
 import { useForm } from 'react-hook-form';
 import TextInput from 'components/shared/input/TextInput';
-import FileInput from 'components/shared/input/FileInput';
+import FileInput, { DroppableFileUploadInput } from 'components/shared/input/FileInput';
 import { useState } from 'react';
 import Button from 'components/shared/Button';
 import styled from 'styled-components';
@@ -31,7 +31,7 @@ const Form = styled.form`
 
 const EmbedImageDialog = ({addEmbeddedImage, showEmbedImageDialog, setShowEmbedImageDialog}) => {
 
-    const {control, setValue, watch, getValues} = useForm({
+    const {control, setValue, watch, getValues, reset: resetForm} = useForm({
         mode: 'all',
         defaultValues: {imageWidth: 0, imageHeight: 0, scalingFactor: 1.0}
     });
@@ -39,15 +39,6 @@ const EmbedImageDialog = ({addEmbeddedImage, showEmbedImageDialog, setShowEmbedI
     const [originalImageWidth, setOriginalImageWidth] = useState(0);
     const [originalImageHeight, setOriginalImageHeight] = useState(0);
     const scalingFactor = watch('scalingFactor');
-    
-    const _addEmbeddedImage = (e) => {
-        e.preventDefault();
-        addEmbeddedImage(
-            imageAttachment, 
-            getValues('imageWidth'),
-            getValues('imageHeight')
-        );
-    }
 
     const onFileChanged = (files) => {
         if(files){
@@ -64,18 +55,18 @@ const EmbedImageDialog = ({addEmbeddedImage, showEmbedImageDialog, setShowEmbedI
         setValue('imageHeight', h);
     }
 
-    const checkImageSize = (image, setSize) => {
+    const checkImageSize = (file, setSize) => {
         //check whether browser fully supports all File API
-        if (window.File && window.FileReader && window.FileList && window.Blob) {
-            const fr = new FileReader();
-            fr.onload = function() { // file is loaded
+        if (file && window.File && window.FileReader && window.FileList && window.Blob) {
+            const fileReader = new FileReader();
+            fileReader.onloadend = function () { // file is loaded
                 const img = new Image();
                 img.onload = function() { // image is loaded; sizes are available
                     setSize(img.width || 0, img.height || 0);
                 };
-                img.src = fr.result; // is the data URL because called with readAsDataURL
+                img.src = fileReader.result; // is the data URL because called with readAsDataURL
             };
-            fr.readAsDataURL(image);
+            fileReader.readAsDataURL(file);
         }
     }
     
@@ -101,23 +92,42 @@ const EmbedImageDialog = ({addEmbeddedImage, showEmbedImageDialog, setShowEmbedI
         setValue('imageHeight', newImageHeight);
         // eslint-disable-next-line
     }, [scalingFactor]);
+
+    const handleClose = () => {
+        console.log('close')
+        setShowEmbedImageDialog(false);
+        setImageAttachment(null);
+        setOriginalImageHeight(0);
+        setOriginalImageWidth(0);
+        resetForm();
+    }
+
+
+    const handleSubmit = () => {
+        addEmbeddedImage(
+            imageAttachment, 
+            getValues('imageWidth'),
+            getValues('imageHeight')
+        );
+        handleClose();
+    }
     
     return(
         <Modal show={showEmbedImageDialog} 
-            onClose={() => setShowEmbedImageDialog(false)}
+            onClose={handleClose}
         >
             <Form 
-                onSubmit={_addEmbeddedImage}
+                onSubmit={handleSubmit}
             >
                 <Header closeButton onClose={() => setShowEmbedImageDialog(false)}>
                     <Title>Add Embedded Image</Title>
                 </Header>
                 <Body>
-                    <FileInput 
-                        label='Browse'
+                    <DroppableFileUploadInput 
                         onFileChanged={onFileChanged}
-                        multiple={false}
-                        accept='image/*'
+                        id='embed-image-upload'
+                        dragLabel='Drag Image Here'
+                        browseLabel='Choose an Image or'
                     />
                     <TextInput 
                         name='scalingFactor'
@@ -155,8 +165,8 @@ const EmbedImageDialog = ({addEmbeddedImage, showEmbedImageDialog, setShowEmbedI
                     
                 </Body>
                 <Footer>
-                    <Button variant="secondary" onClick={() => setShowEmbedImageDialog(false)}>Cancel</Button>
-                    <Button variant="primary" disabled={imageAttachment === null} onClick={_addEmbeddedImage}>OK</Button>
+                    <Button variant="secondary" onClick={handleClose}>Cancel</Button>
+                    <Button variant="primary" disabled={imageAttachment === null} onClick={handleSubmit}>Confirm Embed</Button>
                 </Footer>
             </Form>
         </Modal>

--- a/src/components/EntryEditor/EmbedImageDialog.js
+++ b/src/components/EntryEditor/EmbedImageDialog.js
@@ -20,13 +20,21 @@ import React, { useEffect } from 'react';
 import Modal, {Header, Title, Body, Footer} from '../shared/Modal';
 import { useForm } from 'react-hook-form';
 import TextInput from 'components/shared/input/TextInput';
-import FileInput, { DroppableFileUploadInput } from 'components/shared/input/FileInput';
+import { DroppableFileUploadInput } from 'components/shared/input/FileInput';
 import { useState } from 'react';
 import Button from 'components/shared/Button';
 import styled from 'styled-components';
 
 const Form = styled.form`
+`
 
+const ImageContainer = styled.div`
+    max-height: 50vh;
+    max-width: 50vw;
+    & img {
+        height: 100%;
+        width: 100%;
+    }
 `
 
 const EmbedImageDialog = ({addEmbeddedImage, showEmbedImageDialog, setShowEmbedImageDialog}) => {
@@ -94,14 +102,12 @@ const EmbedImageDialog = ({addEmbeddedImage, showEmbedImageDialog, setShowEmbedI
     }, [scalingFactor]);
 
     const handleClose = () => {
-        console.log('close')
         setShowEmbedImageDialog(false);
         setImageAttachment(null);
         setOriginalImageHeight(0);
         setOriginalImageWidth(0);
         resetForm();
     }
-
 
     const handleSubmit = () => {
         addEmbeddedImage(
@@ -123,12 +129,18 @@ const EmbedImageDialog = ({addEmbeddedImage, showEmbedImageDialog, setShowEmbedI
                     <Title>Add Embedded Image</Title>
                 </Header>
                 <Body>
-                    <DroppableFileUploadInput 
-                        onFileChanged={onFileChanged}
-                        id='embed-image-upload'
-                        dragLabel='Drag Image Here'
-                        browseLabel='Choose an Image or'
-                    />
+                    {imageAttachment 
+                    ?   <ImageContainer>
+                            <img src={URL.createObjectURL(imageAttachment)} alt={`preview of ${imageAttachment.name}`} />
+                        </ImageContainer>
+                    :   <DroppableFileUploadInput 
+                            onFileChanged={onFileChanged}
+                            id='embed-image-upload'
+                            dragLabel='Drag Image Here'
+                            browseLabel='Choose an Image or'
+                        />
+                    }
+                    
                     <TextInput 
                         name='scalingFactor'
                         label='Scaling Factor'

--- a/src/components/EntryEditor/EmbedImageDialog.js
+++ b/src/components/EntryEditor/EmbedImageDialog.js
@@ -37,7 +37,7 @@ const ImageContainer = styled.div`
     }
 `
 
-const EmbedImageDialog = ({addEmbeddedImage, showEmbedImageDialog, setShowEmbedImageDialog}) => {
+const EmbedImageDialog = ({addEmbeddedImage, initialImage=null, setInitialImage, showEmbedImageDialog, setShowEmbedImageDialog}) => {
 
     const {control, setValue, watch, getValues, reset: resetForm} = useForm({
         mode: 'all',
@@ -47,6 +47,13 @@ const EmbedImageDialog = ({addEmbeddedImage, showEmbedImageDialog, setShowEmbedI
     const [originalImageWidth, setOriginalImageWidth] = useState(0);
     const [originalImageHeight, setOriginalImageHeight] = useState(0);
     const scalingFactor = watch('scalingFactor');
+
+    // If provided with an initial image, then use it
+    useEffect(() => {
+        if(initialImage) {
+            setImageAttachment(initialImage);
+        }
+    }, [initialImage])
 
     const onFileChanged = (files) => {
         if(files){
@@ -104,6 +111,7 @@ const EmbedImageDialog = ({addEmbeddedImage, showEmbedImageDialog, setShowEmbedI
     const handleClose = () => {
         setShowEmbedImageDialog(false);
         setImageAttachment(null);
+        setInitialImage(null);
         setOriginalImageHeight(0);
         setOriginalImageWidth(0);
         resetForm();
@@ -125,7 +133,7 @@ const EmbedImageDialog = ({addEmbeddedImage, showEmbedImageDialog, setShowEmbedI
             <Form 
                 onSubmit={handleSubmit}
             >
-                <Header closeButton onClose={() => setShowEmbedImageDialog(false)}>
+                <Header closeButton onClose={handleClose}>
                     <Title>Add Embedded Image</Title>
                 </Header>
                 <Body>

--- a/src/components/EntryEditor/EntryEditor.test.js
+++ b/src/components/EntryEditor/EntryEditor.test.js
@@ -121,6 +121,12 @@ test('embed images successfully', async () => {
     // When we upload an image
     const uploadInput = screen.getByLabelText(/choose an image/i);
     await user.upload(uploadInput, image);
+    
+    // Then it is previewed in the modal
+    const previewedImage = screen.getByRole('img', {name: /preview of hello/i});
+    expect(previewedImage).toBeInTheDocument();
+
+    // And when we confirm embed
     const confirmButton = screen.getByRole('button', {name: /confirm embed/i});
     await user.click(confirmButton);
 

--- a/src/components/EntryEditor/EntryEditor.test.js
+++ b/src/components/EntryEditor/EntryEditor.test.js
@@ -1,8 +1,9 @@
-import { render, screen, waitForElementToBeRemoved } from "test-utils";
+import { render, screen, waitFor } from "test-utils";
 import userEvent from '@testing-library/user-event';
 import EntryEditor from ".";
 import { MemoryRouter } from "react-router-dom";
 import selectEvent from "react-select-event";
+import { ModalProvider } from "styled-react-modal";
 
 test('when an image is uploaded, then it is displayed', async () => {
 
@@ -87,4 +88,63 @@ test('user cannot submit invalid log entries', async () => {
     // cleanup network resources
     unmount();
 
+})
+
+test('embed images successfully', async () => {
+
+    const user = userEvent.setup();
+    render(
+        <MemoryRouter>
+            <ModalProvider>
+                <EntryEditor userData={{username: 'foo'}}/>
+            </ModalProvider>
+        </MemoryRouter>
+    );
+
+    // given an image and copy
+    const image = new File(['hello'], 'hello.png', {type: 'image/png'})
+
+    // And the description field having content in it already
+    const descriptionField = await screen.findByRole('textbox', {name: /description/i});
+    await user.clear(descriptionField);
+    await user.type(descriptionField, 'sometext');
+
+    // when an user clicks the embed image button
+    const embedImageButton = screen.getByRole('button', {name: /embed image/i});
+    await user.click(embedImageButton);
+
+    // then the values are set to default
+    expect(await screen.findByRole('textbox', {name: /scaling factor/i})).toHaveValue('1');
+    expect(await screen.findByRole('textbox', {name: /width/i})).toHaveValue('0');
+    expect(await screen.findByRole('textbox', {name: /height/i})).toHaveValue('0');
+
+    // When we upload an image
+    const uploadInput = screen.getByLabelText(/choose an image/i);
+    await user.upload(uploadInput, image);
+    const confirmButton = screen.getByRole('button', {name: /confirm embed/i});
+    await user.click(confirmButton);
+
+    // Then it is embedded in the description field
+    expect(descriptionField.value).toMatch(/^sometext.*\!\[\]/);
+
+    // And included as an attachment
+    const uploadedImages = await screen.findAllByRole('img', {name: /hello/i});
+    expect(uploadedImages).toHaveLength(1);
+    for(let img of uploadedImages) {
+        expect(img).toBeInTheDocument();
+    }
+
+    // And when the image attachment is removed
+    const deleteImageButton = screen.getByRole('button', {name: /remove hello/i});
+    await user.click(deleteImageButton)
+
+    // Then it is removed as an attachment
+    const removedImage = screen.queryByRole('img', {name: /hello/i});
+    expect(removedImage).not.toBeInTheDocument();
+
+    // And its markup is removed from the description as well
+    await waitFor(async () => {
+        expect(descriptionField).toHaveValue('sometext');
+    })
+    
 })

--- a/src/components/EntryEditor/index.js
+++ b/src/components/EntryEditor/index.js
@@ -476,6 +476,8 @@ const EntryEditor = ({
                             <DroppableFileUploadInput 
                                 onFileChanged={onFileChanged}
                                 id='attachments-upload'
+                                dragLabel='Drag It Here'
+                                browseLabel='Choose a File or'
                             />
                             { renderedAttachments }
                         </RenderedAttachmentsContainer>

--- a/src/components/EntryEditor/index.js
+++ b/src/components/EntryEditor/index.js
@@ -46,28 +46,28 @@ import ExternalLink from 'components/shared/ExternalLink';
 import { APP_BASE_URL } from 'constants';
 
 const Container = styled.div`
-    padding: 0.5rem;
+    padding: 1rem 0.5rem;
     overflow: hidden;
     height: 100%;
     display: flex;
     flex-direction: column;
+    gap: 1rem;
 `
 
 const Form = styled.form`
     display: flex;
     flex-direction: column;
     overflow: auto;
+    gap: 0.5rem;
 `
 
 const DescriptionContainer = styled.div`
     display: flex;
     flex-direction: column;
-    padding: 1rem 0;
-    padding-top: 0;
+    padding-bottom: 1rem;
 `
 
 const DescriptionTextInput = styled(TextInput)`
-    padding-top: 0;
 `
 
 const DescriptionContainerFooter = styled.div`
@@ -97,7 +97,7 @@ const RenderedAttachmentsContainer = styled.div`
     align-items: center;
     gap: 0.5rem;
     padding: 0.5rem;
-    margin: 0.5rem;
+    margin-bottom: 1rem;
     border: solid 1px ${({theme}) => theme.colors.light};
     border-radius: 5px;
 
@@ -122,12 +122,10 @@ const PropertiesContainer = styled.div`
     border: solid 1px ${({theme}) => theme.colors.light};
     border-radius: 5px;
     padding: 0.5rem;
-    margin: 0.5rem;
+    margin-bottom: 1rem;
 `
 
-const DetachedLabel = styled.label`
-    padding: 0 0.5rem;
-`
+const DetachedLabel = styled.label``
 
 const EntryEditor = ({
      tags=[],
@@ -235,7 +233,6 @@ const EntryEditor = ({
         const imageMarkup = "![](attachment/" + id + "){width=" + width + " height=" + height + "}";
         let description = getValues('description') || '';
         description += imageMarkup;
-        setShowEmbedImageDialog(false);
         setValue('description', description, {shouldDirty: false, shouldTouch: false, shouldValidate: false});
     }
 
@@ -365,10 +362,10 @@ const EntryEditor = ({
 
     return (
         <>
-            <Container>
                 <LoadingOverlay
                     active={createInProgress}
                 >
+                    <Container>
                     <h1>New Log Entry</h1>
                     <Form onSubmit={handleSubmit(onSubmit)}>
                         <span ref={topElem}></span>
@@ -481,6 +478,7 @@ const EntryEditor = ({
                             />
                             { renderedAttachments }
                         </RenderedAttachmentsContainer>
+                        <DetachedLabel>Properties</DetachedLabel>
                         <PropertiesContainer>
                             <Button variant="secondary" size="sm" onClick={(e) => {
                                 e.preventDefault();
@@ -496,8 +494,8 @@ const EntryEditor = ({
                         </PropertiesContainer>
                         <Button type='submit' variant="primary" disabled={userData.userName === "" || createInProgress} >Submit</Button>
                     </Form>
-                </LoadingOverlay>
-            </Container>
+                </Container>
+            </LoadingOverlay>
             <Modal show={showAddProperty} onClose={() => setShowAddProperty(false)}>
                 <Header onClose={() => setShowAddProperty(false)}>
                     <Title>Add Property</Title>

--- a/src/components/EntryEditor/index.js
+++ b/src/components/EntryEditor/index.js
@@ -149,6 +149,7 @@ const EntryEditor = ({
     // File input HTML element ref allows us to hide
     // the element and click it from e.g. a button
     // const fileInputRef = useRef(null);
+    const [initialImage, setInitialImage] = useState(null);
     const [createInProgress, setCreateInProgress] = useState(false);
     const [showEmbedImageDialog, setShowEmbedImageDialog] = useState(false);
     const [showHtmlPreview, setShowHtmlPreview] = useState(false);
@@ -360,6 +361,22 @@ const EntryEditor = ({
         );
     })
 
+    const handlePaste = (e) => {
+        const items = e.clipboardData.items;
+        let imageFile = null;
+        for(let item of items) {
+            if(item.kind === 'file' && item.type.match(/^image/)) {
+                imageFile = item.getAsFile();
+            }
+        }
+        if(imageFile) {
+            setInitialImage(imageFile);
+            setShowEmbedImageDialog(true);
+            // prevent paste of image 'text'
+            e.preventDefault();
+        }
+    }
+
     return (
         <>
                 <LoadingOverlay
@@ -367,7 +384,7 @@ const EntryEditor = ({
                 >
                     <Container>
                     <h1>New Log Entry</h1>
-                    <Form onSubmit={handleSubmit(onSubmit)}>
+                    <Form onSubmit={handleSubmit(onSubmit)} >
                         <span ref={topElem}></span>
                         <MultiSelect
                             name='logbooks'
@@ -441,6 +458,7 @@ const EntryEditor = ({
                                 defaultValue=''
                                 textArea
                                 rows={10}
+                                onPaste={handlePaste}
                             />
                             <DescriptionContainerFooter>
                                 <div>
@@ -511,6 +529,8 @@ const EntryEditor = ({
             <EmbedImageDialog showEmbedImageDialog={showEmbedImageDialog} 
                 setShowEmbedImageDialog={setShowEmbedImageDialog}
                 addEmbeddedImage={addEmbeddedImage}
+                initialImage={initialImage}
+                setInitialImage={setInitialImage}
             />
             <HtmlPreview showHtmlPreview={showHtmlPreview}
                 setShowHtmlPreview={setShowHtmlPreview}

--- a/src/components/shared/input/FileInput.js
+++ b/src/components/shared/input/FileInput.js
@@ -80,7 +80,7 @@ const StyledClickableArea = styled.div`
     text-align: center;
 `
 
-export const DroppableFileUploadInput = ({id, onFileChanged, className, multiple, accept}) => {
+export const DroppableFileUploadInput = ({id, onFileChanged, className, multiple, accept, dragLabel, browseLabel}) => {
 
     const fileInputRef = useRef();
 
@@ -124,11 +124,10 @@ export const DroppableFileUploadInput = ({id, onFileChanged, className, multiple
             onDragOver={handleDragEnter} 
             onDragLeave={handleDragLeave}
             className={className}
-            
         >
             <StyledClickableArea onClick={onClick}>
                 <MdFileUpload size={'5rem'}/>
-                <label htmlFor={id} >Choose a File or <strong>Drag It Here</strong></label>
+                <label htmlFor={id} >{browseLabel} <strong>{dragLabel}</strong></label>
             </StyledClickableArea>
             <input
                 id={id}

--- a/src/components/shared/input/LabeledInput.js
+++ b/src/components/shared/input/LabeledInput.js
@@ -4,7 +4,6 @@ import ErrorMessage from "./ErrorMessage";
 const Container = styled.div`
     display: flex;
     flex-direction: ${({inlineLabel}) => inlineLabel ? 'row' : 'column'};    
-    padding: 0 0.5rem;
     padding-bottom: 1rem;
     width: 100%;
     ${({inlineLabel}) => inlineLabel ? `

--- a/src/components/shared/input/TextInput.js
+++ b/src/components/shared/input/TextInput.js
@@ -57,7 +57,7 @@ export const StyledLabeledTextInput = React.forwardRef(({name, label, message, c
     );
 });
 
-export const TextInput = ({name, label, control, rules, defaultValue, className, textArea=false, rows=3, password=false, inlineLabel}) => {
+export const TextInput = ({name, label, control, rules, defaultValue, className, textArea=false, rows=3, password=false, inlineLabel, ...props}) => {
     
     const {field, fieldState} = useController({name, control, rules, defaultValue});
 
@@ -72,8 +72,9 @@ export const TextInput = ({name, label, control, rules, defaultValue, className,
             ref: field.ref, 
             value:field.value, 
             onChange:field.onChange,
-            inlineLabel
+            inlineLabel,
         }}
+        {...props}
     />
     
 }


### PR DESCRIPTION
## Summary of Changes

- Feature: embed image directly into the Description field by pasting it from your clipboard (pasting regular text works as before)
- Refactor: use the same file upload control in the embed image upload as attachments, including with image preview
- Fix: Previous image information remains in the embed image modal after closing or confirming
- Fix: Inaccessible delete attachment button

![2023-02-17 09 43 14](https://user-images.githubusercontent.com/77395846/219596980-c0e8cf1f-7d9f-40b2-bf44-7aaa2ffc6b71.gif)


## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [ ] Overall layout fills full width and height of viewport
- [ ] Pagination element doesn't overflow into other elements
