### PR TITLE
Csstudio 1855 - Accessible / Semantic Banner

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -34,7 +34,7 @@ const ViewportContainer = styled.div`
     flex-direction: column;
 `
 
-const ContentContainer = styled.div`
+const ContentContainer = styled.main`
     overflow: auto;
     height: 100%;
 `

--- a/src/components/Banner/index.js
+++ b/src/components/Banner/index.js
@@ -25,6 +25,7 @@ import ologService from '../../api/olog-service';
 import packageInfo from '../../../package.json';
 import styled from 'styled-components';
 import { useEffect } from 'react';
+import SkipToContent from 'components/shared/SkipToContent';
 
 const Navbar = styled.nav`
   & ul {
@@ -113,6 +114,7 @@ const Banner = ({userData, setUserData, showLogin, setShowLogin, showLogout, set
   return (
     <header>
       <Navbar>
+        <SkipToContent href='#app-content'>Skip to Main Content</SkipToContent>
         <ul>
           <NavHeader>
             <li><Link to="/">

--- a/src/components/Banner/index.js
+++ b/src/components/Banner/index.js
@@ -27,12 +27,14 @@ import styled from 'styled-components';
 import { useEffect } from 'react';
 
 const Navbar = styled.nav`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  background-color: #343a40;
-  color: #fff;
-  padding: 1vh 2vw;
+  & ul {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    background-color: #343a40;
+    color: #fff;
+    padding: 1vh 2vw;
+  }
 `
 
 const NavHeader = styled.div`
@@ -45,10 +47,10 @@ const NavFooter = styled.div`
   display: flex;
   align-items: center;
 `
-const PackageName = styled.h1`
+const PackageName = styled.div`
   font-size: 1.4em;
 `
-const PackageVersion = styled.h2`
+const PackageVersion = styled.div`
   font-size: 0.8em;
 `
 
@@ -109,9 +111,27 @@ const Banner = ({userData, setUserData, showLogin, setShowLogin, showLogout, set
   }
 
   return (
-    <>
+    <header>
       <Navbar>
-        <NavHeader>
+        <ul>
+          <NavHeader>
+            <li><Link to="/">
+              <PackageName>{packageInfo.name}</PackageName>
+              <PackageVersion>{packageInfo.version}</PackageVersion>
+            </Link></li>
+            <li><Link to="/edit">
+              <Button disabled={!userData.userName} 
+                variant='primary'
+                onClick={() => handleNewLogEntry()}>New Log Entry</Button>
+            </Link></li>
+          </NavHeader>
+          <NavFooter>
+            <li><Button onClick={handleClick} variant="primary">
+              {userData.userName ? userData.userName : 'Sign In'}
+            </Button></li>
+          </NavFooter>
+        </ul>
+        {/* <NavHeader>
           <Link to="/">
             <PackageName>{packageInfo.name}</PackageName>
             <PackageVersion>{packageInfo.version}</PackageVersion>
@@ -126,7 +146,7 @@ const Banner = ({userData, setUserData, showLogin, setShowLogin, showLogout, set
           <Button onClick={handleClick} variant="primary">
             {userData.userName ? userData.userName : 'Sign In'}
           </Button>
-        </NavFooter>
+        </NavFooter> */}
       </Navbar>
 
       <LoginDialog setUserData={setUserData} 
@@ -137,7 +157,7 @@ const Banner = ({userData, setUserData, showLogin, setShowLogin, showLogout, set
                       setShowLogout={setShowLogout} 
                       logoutDialogVisible={showLogout}/>
 
-    </>
+    </header>
   )
   
 }

--- a/src/components/shared/SkipToContent.js
+++ b/src/components/shared/SkipToContent.js
@@ -1,0 +1,27 @@
+import styled from "styled-components";
+
+const StyledAnchor = styled.a`
+    left: -50%;
+    position: absolute;
+    font-size: 1.5rem;
+    background-color: ${({theme}) => theme.colors.light};
+    padding: 0.5rem 1rem;
+    z-index: 999;
+    text-decoration: underline;
+
+    transition: all 300ms linear;
+
+    &:focus {
+        left: 0;
+    }
+`
+
+const SkipToContent = ({children, ...props}) => {
+    return (
+        <StyledAnchor tabIndex={0} {...props} >
+            {children}
+        </StyledAnchor>
+    )
+}
+
+export default SkipToContent;

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,11 @@ const GlobalStyle = createGlobalStyle`
     a:visited {
         color: inherit;
     }
+
+    *:focus-visible {
+        outline: 3px solid orange;
+        outline-offset: 1px;
+    }
 `;
 
 const container = document.getElementById('root');


### PR DESCRIPTION
## Summary of Changes

- Wraps banner in header
- Places nav elements in ul / li
- Adds "skip to main content" link
- Uses main element for app content

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [ ] Overall layout fills full width and height of viewport
- [ ] Pagination element doesn't overflow into other elements
