### PR TITLE
CSSTUDIO-1856: Accessible disabled buttons

### DIFF
--- a/src/api/olog-service.js
+++ b/src/api/olog-service.js
@@ -62,7 +62,7 @@ export function checkSession () {
     // If server returns user data with non-null userName, there is a valid session.
     return ologService.get('/user', { withCredentials: true })
             .then(res => {return res.data})
-            .catch(err => alert("Unable to check login session: " + err));
+            .catch(err => console.warn("Unable to check login session: ", err));
 }
 
 export default ologService;

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -90,8 +90,9 @@ const App = () => {
                         <EntryEditor {...{
                             tags,
                             logbooks,
-                            replyAction,
-                            userData, setUserData
+                            replyAction, setReplyAction,
+                            userData, setUserData,
+                            setShowLogin
                         }}/>
                     } />
                 </Routes>

--- a/src/components/App.test.js
+++ b/src/components/App.test.js
@@ -422,7 +422,7 @@ describe('Login/Logout', () => {
         );
     
         // when rendered
-        const {container} = render(
+        render(
             <MemoryRouter initialEntries={['/edit']}>
                 <ModalProvider>
                     <App />
@@ -430,7 +430,6 @@ describe('Login/Logout', () => {
             </MemoryRouter>
         );
     
-        screen.debug(container, 100000000)
         // then login is displayed
         const passwordField = await screen.findByLabelText(/password/i);
         expect(passwordField).toBeInTheDocument();

--- a/src/components/Banner/index.js
+++ b/src/components/Banner/index.js
@@ -16,7 +16,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-import Button from '../shared/Button';
+import Button, { buttonBaseStyle } from '../shared/Button';
 import {Link} from "react-router-dom";
 import LoginDialog from '../LoginLogout/LoginDialog';
 import LogoutDialog from '../LoginLogout/LogoutDialog';
@@ -55,6 +55,11 @@ const PackageVersion = styled.div`
   font-size: 0.8em;
 `
 
+const NewLogEntryLinkButton = styled(Link)`
+  ${buttonBaseStyle}
+  background-color: ${({theme}) => theme.colors.primary};
+`
+
 /**
  * Banner component with controls to create log entry, log book or tag. Plus
  * button for signing in/out. 
@@ -84,24 +89,6 @@ const Banner = ({userData, setUserData, showLogin, setShowLogin, showLogout, set
     }
   }, [setUserData])
 
-  const handleNewLogEntry = () => {
-    
-    var promise = checkSession();
-    if(!promise){
-      setShowLogin(true);
-    }
-    else{
-      promise.then(data => {
-        if(!data){
-          setShowLogin(true);
-        }
-        else{
-          setReplyAction(false);
-        }
-      });
-    }
-  }
-
   const handleClick = () => {
     if(!userData.userName){
         setShowLogin(true);
@@ -117,15 +104,14 @@ const Banner = ({userData, setUserData, showLogin, setShowLogin, showLogout, set
         <SkipToContent href='#app-content'>Skip to Main Content</SkipToContent>
         <ul>
           <NavHeader>
-            <li><Link to="/">
+            <li><Link to="/" aria-label='home'>
               <PackageName>{packageInfo.name}</PackageName>
               <PackageVersion>{packageInfo.version}</PackageVersion>
             </Link></li>
-            <li><Link to="/edit">
-              <Button disabled={!userData.userName} 
-                variant='primary'
-                onClick={() => handleNewLogEntry()}>New Log Entry</Button>
-            </Link></li>
+
+            <li><NewLogEntryLinkButton to="/edit" >
+              New Log Entry
+            </NewLogEntryLinkButton></li>
           </NavHeader>
           <NavFooter>
             <li><Button onClick={handleClick} variant="primary">
@@ -133,22 +119,6 @@ const Banner = ({userData, setUserData, showLogin, setShowLogin, showLogout, set
             </Button></li>
           </NavFooter>
         </ul>
-        {/* <NavHeader>
-          <Link to="/">
-            <PackageName>{packageInfo.name}</PackageName>
-            <PackageVersion>{packageInfo.version}</PackageVersion>
-          </Link>
-          <Link to="/edit">
-            <Button disabled={!userData.userName} 
-              variant='primary'
-              onClick={() => handleNewLogEntry()}>New Log Entry</Button>
-          </Link>
-        </NavHeader>
-        <NavFooter>
-          <Button onClick={handleClick} variant="primary">
-            {userData.userName ? userData.userName : 'Sign In'}
-          </Button>
-        </NavFooter> */}
       </Navbar>
 
       <LoginDialog setUserData={setUserData} 

--- a/src/components/Banner/index.js
+++ b/src/components/Banner/index.js
@@ -20,7 +20,6 @@ import Button, { buttonBaseStyle } from '../shared/Button';
 import {Link} from "react-router-dom";
 import LoginDialog from '../LoginLogout/LoginDialog';
 import LogoutDialog from '../LoginLogout/LogoutDialog';
-import { checkSession } from '../../api/olog-service';
 import ologService from '../../api/olog-service';
 import packageInfo from '../../../package.json';
 import styled from 'styled-components';

--- a/src/components/EntryEditor/index.js
+++ b/src/components/EntryEditor/index.js
@@ -130,8 +130,9 @@ const DetachedLabel = styled.label``
 const EntryEditor = ({
      tags=[],
      logbooks=[],
-     replyAction,
-     userData, setUserData
+     replyAction, setReplyAction=() => {},
+     userData, setUserData,
+     setShowLogin=() => {}
     }) => {
 
     const topElem = useRef();
@@ -168,6 +169,26 @@ const EntryEditor = ({
         storage: window.localStorage,
         exclude: 'attachments', // serializing files is unsupported due to security risks
     });
+
+    /**
+     * Show login if no session
+     */
+    useEffect(() => {
+        const promise = checkSession();
+        if(!promise){
+            setShowLogin(true);
+        }
+        else{
+            promise.then(data => {
+                if(!data){
+                setShowLogin(true);
+                }
+                else{
+                setReplyAction(false);
+                }
+            });
+        }
+    }, [setShowLogin, setReplyAction])
     
     /**
      * If currentLogEntry is defined, use it as a "template", i.e. user is replying to a log entry.

--- a/src/components/shared/Button.js
+++ b/src/components/shared/Button.js
@@ -2,7 +2,7 @@ import { useState } from "react";
 import styled, { css } from "styled-components";
 
 export const buttonBaseStyle = css`
-    ${({hidden, variant, theme, disabled}) => hidden ? '' : `
+    ${({hidden, variant, theme}) => hidden ? '' : `
         display: flex;
         justify-content: center;
         align-items: center;
@@ -13,27 +13,41 @@ export const buttonBaseStyle = css`
         border-radius: 5px;
         background-color: ${ theme.colors[variant] || theme.colors.default };
         color: #fff;
-        cursor: ${disabled ? 'not-allowed' : 'pointer'};
-        filter: ${disabled ? 'brightness(0.7) opacity(50%)' : 'none'};
+        cursor: pointer;
+        filter: none;
         
+        &[aria-disabled=true] {
+            cursor: not-allowed;
+            opacity: 0.50;
+        }
+
         &:hover {
             filter: brightness(0.7);
         }
     `}
 `
 
-const ButtonElem = styled.button`
+const StyledButton = styled.button`
     ${buttonBaseStyle}
 `
 
 // const Button = ({type='button', variant, disabled=false, onClick=() => {}, innerRef, className, hidden, children}) => {
 const Button = ({type='button', variant, disabled=false, onClick=() => {}, innerRef, className, children, ...props}) => {
-    return <ButtonElem type={type} {...{variant, disabled, onClick, className, ref: innerRef, ...props}}>
+
+    const handleClick = (e) => {
+        if(disabled) {
+            e.preventDefault();
+            e.preventPropagation();
+        }
+        onClick(e);
+    }
+
+    return <StyledButton onClick={handleClick} type={type} {...{variant, className, ref: innerRef, ...props}} aria-disabled={disabled} >
         {children}
-    </ButtonElem>
+    </StyledButton>
 }
 
-const StyledToggleButton = styled(ButtonElem)`
+const StyledToggleButton = styled(StyledButton)`
     background-color: ${({checked, variant, theme}) => checked ? (theme.colors[variant] || theme.colors.default) : 'transparent'};
     border: 1px solid ${({variant, theme}) => theme.colors[variant] || theme.colors.default};
     color: ${({checked, variant, theme}) => checked ? theme.colors.lightest : (theme.colors[variant] || theme.colors.default)};

--- a/src/components/shared/Button.js
+++ b/src/components/shared/Button.js
@@ -37,9 +37,10 @@ const Button = ({type='button', variant, disabled=false, onClick=() => {}, inner
     const handleClick = (e) => {
         if(disabled) {
             e.preventDefault();
-            e.preventPropagation();
+            e.stopPropagation();
+        } else {
+            onClick(e);
         }
-        onClick(e);
     }
 
     return <StyledButton onClick={handleClick} type={type} {...{variant, className, ref: innerRef, ...props}} aria-disabled={disabled} >

--- a/src/components/shared/Button.test.js
+++ b/src/components/shared/Button.test.js
@@ -1,0 +1,34 @@
+import { render, screen } from 'test-utils';
+import Button from './Button';
+import userEvent from '@testing-library/user-event'
+
+test('disabled buttons are focusable but ignore actions', async () => {
+
+    // Given we render an enabled and disabled button
+    const enabledOnClick = jest.fn();
+    const disabledOnClick = jest.fn();
+    const user = userEvent.setup();
+    render(
+        <div>
+            <Button onClick={enabledOnClick}>enabled button</Button>
+            <Button onClick={disabledOnClick} disabled>disabled button</Button>
+        </div>
+    )
+
+    // We expect the buttons are both enabled but the disabled button has aria-disabled=true
+    const enabledButton = screen.getByRole('button', {name: 'enabled button'});
+    const disabledButton = screen.getByRole('button', {name: 'disabled button'});
+    expect(enabledButton).toBeEnabled();
+    expect(enabledButton).toHaveAttribute('aria-disabled', 'false');
+    expect(disabledButton).toBeEnabled();
+    expect(disabledButton).toHaveAttribute('aria-disabled', 'true');
+
+    // When we click each
+    await user.click(enabledButton);
+    await user.click(disabledButton);
+
+    // Only the enabled button should have executed is onclick action
+    expect(enabledOnClick).toBeCalled();
+    expect(disabledOnClick).not.toBeCalled();
+
+})

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ const GlobalStyle = createGlobalStyle`
     *:focus-visible {
         outline: 3px solid orange;
         outline-offset: 1px;
+        z-index: 9999;
     }
 `;
 


### PR DESCRIPTION
## Summary of Changes

- buttons are accessible via keyboard when disabled, but otherwise appear disabled and do not execute any actions
- Create New Log Entry button is now a link (not both a button and link; improved semantics / accessibility)
- refactor: move session check to log entry form on load

Note, there is a larger UX question here of whether we should even show the New Log Entry button at all when the user isn't logged in. Disabled links don't make sense, so this favors removing the link completely if not logged in. However, users have come to expect that link to be there and be "disabled" when not logged in. 

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [ ] Overall layout fills full width and height of viewport
- [ ] Pagination element doesn't overflow into other elements
