### PR TITLE
Csstudio-1867: Attach multiple attachments Olog web client

### DIFF
--- a/src/components/Attachment/index.js
+++ b/src/components/Attachment/index.js
@@ -129,7 +129,7 @@ const Attachment = ({attachment, removeAttachment, className}) => {
         <>
             <Container className={className}>
                 <ImageHeader>
-                    <CloseIcon onClick={() => removeAttachment(attachment.file)} aria-label={`remove ${attachment.file.name}`}>
+                    <CloseIcon type='button' onClick={() => removeAttachment(attachment.file)} aria-label={`remove ${attachment.file.name}`}>
                         <BsXCircle />
                     </CloseIcon>
                 </ImageHeader>

--- a/src/components/EntryEditor/EntryEditor.test.js
+++ b/src/components/EntryEditor/EntryEditor.test.js
@@ -16,7 +16,7 @@ test('when an image is uploaded, then it is displayed', async () => {
 
     // upload an attachment
     const file = new File(['hello'], 'hello.png', {type: 'image/png'})
-    const uploadInput = screen.getByLabelText(/choose a file/i);
+    const uploadInput = screen.getByLabelText(/choose file\(s\)/i);
     await user.upload(uploadInput, file);
 
     // check it is rendered on the page
@@ -37,7 +37,7 @@ test('when many images are uploaded simultaneously, then all are displayed', asy
     // upload an attachment
     const file1 = new File(['hello'], 'hello.png', {type: 'image/png'})
     const file2 = new File(['goodday'], 'goodday.png', {type: 'image/png'})
-    const uploadInput = screen.getByLabelText(/choose a file/i);
+    const uploadInput = screen.getByLabelText(/choose file\(s\)/i);
     await user.upload(uploadInput, [file1, file2]);
 
     // check it is rendered on the page
@@ -59,7 +59,7 @@ test('can upload a file with the same name', async () => {
     // upload an attachment
     const file = new File(['hello'], 'hello.png', {type: 'image/png'})
     const fileCopy = new File(['hello'], 'hello.png', {type: 'image/png'})
-    const uploadInput = screen.getByLabelText(/choose a file/i);
+    const uploadInput = screen.getByLabelText(/choose file\(s\)/i);
     await user.upload(uploadInput, file);
     await user.upload(uploadInput, fileCopy);
 

--- a/src/components/EntryEditor/EntryEditor.test.js
+++ b/src/components/EntryEditor/EntryEditor.test.js
@@ -25,6 +25,29 @@ test('when an image is uploaded, then it is displayed', async () => {
 
 })
 
+test('when many images are uploaded simultaneously, then all are displayed', async () => {
+
+    const user = userEvent.setup();
+    render(
+        <MemoryRouter>
+            <EntryEditor userData={{username: 'foo'}}/>
+        </MemoryRouter>
+    );
+
+    // upload an attachment
+    const file1 = new File(['hello'], 'hello.png', {type: 'image/png'})
+    const file2 = new File(['goodday'], 'goodday.png', {type: 'image/png'})
+    const uploadInput = screen.getByLabelText(/choose a file/i);
+    await user.upload(uploadInput, [file1, file2]);
+
+    // check it is rendered on the page
+    const uploadedImage1 = await screen.findByRole('img', {name: /hello/i});
+    const uploadedImage2 = await screen.findByRole('img', {name: /goodday/i});
+    expect(uploadedImage1).toBeInTheDocument();
+    expect(uploadedImage2).toBeInTheDocument();
+
+})
+
 test('can upload a file with the same name', async () => {
     const user = userEvent.setup();
     render(

--- a/src/components/EntryEditor/index.js
+++ b/src/components/EntryEditor/index.js
@@ -514,6 +514,7 @@ const EntryEditor = ({
                                 id='attachments-upload'
                                 dragLabel='Drag It Here'
                                 browseLabel='Choose a File or'
+                                multiple
                             />
                             { renderedAttachments }
                         </RenderedAttachmentsContainer>

--- a/src/components/EntryEditor/index.js
+++ b/src/components/EntryEditor/index.js
@@ -512,8 +512,8 @@ const EntryEditor = ({
                             <DroppableFileUploadInput 
                                 onFileChanged={onFileChanged}
                                 id='attachments-upload'
-                                dragLabel='Drag It Here'
-                                browseLabel='Choose a File or'
+                                dragLabel='Drag Here'
+                                browseLabel='Choose File(s) or'
                                 multiple
                             />
                             { renderedAttachments }


### PR DESCRIPTION
## Summary of Changes

- fix: could not attach many attachments simultaneously in the log entry form
- fix: sometimes form may submit due to button type 'default' when deleting an attachment from the form

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [ ] Overall layout fills full width and height of viewport
- [ ] Pagination element doesn't overflow into other elements
