### PR TITLE
Csstudio-1886: Display of Markdown List Elements Containing Paragraphs

### DIFF
--- a/src/components/EntryEditor/index.js
+++ b/src/components/EntryEditor/index.js
@@ -180,7 +180,6 @@ const EntryEditor = ({
         }
         else{
             promise.then(data => {
-                console.log(data);
                 if(!data){
                     setShowLogin(true);
                 }

--- a/src/components/shared/HtmlContent.js
+++ b/src/components/shared/HtmlContent.js
@@ -44,8 +44,20 @@ const Container = styled.div`
     }
 
     /** Lists **/
-    ul {
+    /** Unfortunately no good way of using selectors
+     *  to enforce alternating bullet styles purely
+     *  with CSS; this supports six levels, which 
+     *  should be enough 
+     **/
+    ul,
+    li, li li li, li li li li li {
         list-style: disc inside;
+    }
+    li li, li li li li, li li li li li li {
+        list-style: circle inside;
+    }
+    li li li, li li li li li {
+        list-style: square inside;
     }
     ol {
         list-style: decimal inside;

--- a/src/components/shared/HtmlContent.js
+++ b/src/components/shared/HtmlContent.js
@@ -23,6 +23,9 @@ const Container = styled.div`
     p {
         padding: 1rem 0;
     }
+    h3, h4 {
+        padding-bottom: 0.5rem;
+    }
     
     /** Links **/
     a, a:visited {
@@ -47,9 +50,19 @@ const Container = styled.div`
     ol {
         list-style: decimal inside;
     }
+    ul, ol,
     li > ul,
     li > ol {
         padding-left: 2rem;
+    }
+    li > p {
+        /* prevent newline for paragraphs inside of list items */
+        display: inline-block;
+        padding-bottom: 0.25rem;
+    }
+    ul + *, 
+    ol + * {
+        padding-top: 1rem;
     }
 
     /** Code **/


### PR DESCRIPTION
## Summary of Changes
When inserting markdown, the html generated may include paragraph elements instead of raw text in the list elements. In those cases, the elements were being rendered on the next line from the bullet rather than the same line. 

This PR also includes changes to:

- spacing around list elements and proceeding/preceeding text
- alternating bullet styles on indented elements

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [ ] Overall layout fills full width and height of viewport
- [ ] Pagination element doesn't overflow into other elements
