### PR TITLE
CSSTUDIO-1893: add title to advanced search

### DIFF
--- a/e2e/cypress/e2e/happy-paths.cy.js
+++ b/e2e/cypress/e2e/happy-paths.cy.js
@@ -60,11 +60,10 @@ describe('Happy Paths', () => {
     cy.findByRole('button', {name: /submit/i}).click();
 
     // expect to find the entry we created
-    cy.findByRole('heading', {name: title, level: 3}).click();
+    cy.findByRole('heading', {name: title, level: 3, timeout: 10000}).click(); // increased timeout due to server performance changes
     cy.findByRole('button', {name: /attachments/i}).click();
     cy.findByRole('img', {name: /testImage/i}).should('exist');
 
   })
-
   
 })

--- a/e2e/cypress/e2e/happy-paths.cy.js
+++ b/e2e/cypress/e2e/happy-paths.cy.js
@@ -16,7 +16,7 @@ describe('Happy Paths', () => {
     cy.visit('/');
 
     // Perform a search that should return the seed data (Should see 35 results from the seeding <30 seconds ago)
-    cy.findByRole('searchbox', {name: /Search/i}).clear().type('start=1 min{Enter}');
+    cy.findByRole('searchbox', {name: /Search/i}).clear().type('start=5 min{Enter}');
 
     // Set the page size as expected
     cy.findByRole('textbox', {name: /hits per page/i}).clear().type('30{Enter}');

--- a/src/components/App.test.js
+++ b/src/components/App.test.js
@@ -6,7 +6,6 @@ import userEvent from '@testing-library/user-event';
 import selectEvent from 'react-select-event';
 import { MemoryRouter } from 'react-router-dom';
 import customization from 'utils/customization';
-import { delay } from 'utils';
 import { ModalProvider } from 'styled-react-modal';
 
 it('renders without crashing', async () => {
@@ -74,6 +73,7 @@ describe('Search Results', () => {
         // Open the filters
         const filterToggle = await screen.findByRole('button', {name: /Show Search Filters/i});
         user.click(filterToggle);
+        await screen.findByRole('heading', {name: /advanced search/i})
     
         // Enter search query for title
         const titleInput = await screen.findByRole('textbox', {name: /title/i});
@@ -104,6 +104,7 @@ describe('Search Results', () => {
         // Open the filters area
         const filterToggle = await screen.findByRole('button', {name: /Show Search Filters/i});
         user.click(filterToggle);
+        await screen.findByRole('heading', {name: /advanced search/i})
     
         // select a tag
         await selectEvent.select(await screen.findByLabelText(/Tags/i), ['foo']);
@@ -133,6 +134,7 @@ describe('Search Results', () => {
         // Open the filters
         const filterToggle = await screen.findByRole('button', {name: /Show Search Filters/i});
         user.click(filterToggle);
+        await screen.findByRole('heading', {name: /advanced search/i})
     
         // select a logbook
         await selectEvent.select(await screen.findByLabelText(/Logbooks/i), ['test controls']);
@@ -174,6 +176,7 @@ describe('Search Results', () => {
         // Update the sort direction
         const filterToggle = screen.getByRole('button', {name: /show search filters/i})
         await user.click(filterToggle);
+        await screen.findByRole('heading', {name: /advanced search/i})
         const sortAscending = screen.getByRole('radio', {name: /ascending/i});
         await user.click(sortAscending);
         elems = await findAllByRole('heading', {name: /log entry \d/})

--- a/src/components/Filters/index.js
+++ b/src/components/Filters/index.js
@@ -32,7 +32,9 @@ const StyledCollapse = styled(Collapse)`
 `
 
 const Container = styled.div`
-
+ & h2 {
+    padding-bottom: 1rem;
+ }
 `
 
 const Form = styled.form`
@@ -86,7 +88,8 @@ const Filters = ({showFilters, logbooks, tags, className}) => {
     return(
         <StyledCollapse show={showFilters} onExiting={handleSubmit(onSubmit)} >
             <Container style={{padding: "8px"}} className={className} >
-                <Form onSubmit={handleSubmit(onSubmit)}>
+                <h2 id="advanced-search">Advanced Search</h2>
+                <Form onSubmit={handleSubmit(onSubmit)} aria-labelledby='advanced-search' role='search' >
                     {/* Hidden button handles submit-on-enter automatically */}
                     <Button type='submit' hidden >Submit</Button>
                     <TextInput 


### PR DESCRIPTION
## Summary of Changes
Adds title to advanced search (ux)
Updates role of form to "search" per https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/form_role

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [ ] Overall layout fills full width and height of viewport
- [ ] Pagination element doesn't overflow into other elements
