### PR TITLE
CSSTUDIO-1896: replace left/right arrow toggle for advanced search with link-like text under search box

### DIFF
--- a/src/components/App.test.js
+++ b/src/components/App.test.js
@@ -71,8 +71,8 @@ describe('Search Results', () => {
         });
     
         // Open the filters
-        const filterToggle = await screen.findByRole('button', {name: /Show Search Filters/i});
-        user.click(filterToggle);
+        const showAdvancedSearchButton = await screen.findByRole('button', {name: /show advanced search/i});
+        user.click(showAdvancedSearchButton);
         await screen.findByRole('heading', {name: /advanced search/i})
     
         // Enter search query for title
@@ -81,7 +81,8 @@ describe('Search Results', () => {
         await user.type(titleInput, 'some value');
         
         // Close the filters
-        user.click(filterToggle);
+        const hideAdvancedSearchButton = await screen.findByRole('button', {name: /hide advanced search/i});
+        user.click(hideAdvancedSearchButton);
     
         // then the results are updated
         expect(await screen.findByText("hmmm title")).toBeInTheDocument();
@@ -102,7 +103,7 @@ describe('Search Results', () => {
         });
     
         // Open the filters area
-        const filterToggle = await screen.findByRole('button', {name: /Show Search Filters/i});
+        const filterToggle = await screen.findByRole('button', {name: /show advanced search/i});
         user.click(filterToggle);
         await screen.findByRole('heading', {name: /advanced search/i})
     
@@ -132,7 +133,7 @@ describe('Search Results', () => {
         });
     
         // Open the filters
-        const filterToggle = await screen.findByRole('button', {name: /Show Search Filters/i});
+        const filterToggle = await screen.findByRole('button', {name: /show advanced search/i});
         user.click(filterToggle);
         await screen.findByRole('heading', {name: /advanced search/i})
     
@@ -174,7 +175,7 @@ describe('Search Results', () => {
         expect(elems.map(it => it.textContent)).toEqual(['log entry 3', 'log entry 2', 'log entry 1']);
     
         // Update the sort direction
-        const filterToggle = screen.getByRole('button', {name: /show search filters/i})
+        const filterToggle = screen.getByRole('button', {name: /show advanced search/i})
         await user.click(filterToggle);
         await screen.findByRole('heading', {name: /advanced search/i})
         const sortAscending = screen.getByRole('radio', {name: /ascending/i});

--- a/src/components/SearchResult/SearchBox.js
+++ b/src/components/SearchResult/SearchBox.js
@@ -22,9 +22,18 @@ import SearchBoxInput from "./SearchBoxInput"
 
 const Container = styled.div`
     width: 100%;
+    padding: 0.25rem 0.5rem;
     display: flex;
-    gap: 0.25rem; 
-    padding: 0.25rem 0.5rem ;
+    flex-direction: column;
+    gap: 0.25rem;
+    & > .searchbox {
+        display: flex;
+        gap: 0.25rem; 
+    }
+    & .advanced-search {
+        display: flex;
+        justify-content: flex-end;
+    }
 `
 
 const StyledSearchBoxInput = styled(SearchBoxInput)`
@@ -32,9 +41,16 @@ const StyledSearchBoxInput = styled(SearchBoxInput)`
     flex-grow: 1;
 `
 
-const FilterButton = styled(Button)`
-    width: 1rem;
-    padding: 0 1rem;
+const FilterLinkToggle = styled.button`
+    padding: 0;
+    border: none;
+    background: none;
+    color: blue;
+    font-style: italic;
+    &:hover {
+        text-decoration: underline;
+        cursor: pointer;
+    }
 `
 
 const HelpButton = styled(Button)`
@@ -53,11 +69,15 @@ const SearchBox = ({searchParams, showFilters, setShowFilters, className}) => {
     
     return (
         <Container className={className} >
-            <FilterButton variant='primary' onClick={(e) => toggleFilters(e)} aria-label="Show Search Filters" >{showFilters ? ">" : "<"}</FilterButton>
-            <StyledSearchBoxInput
-                {...{searchParams, showFilters, isFetching: true}}
-            />
-            <HelpButton variant='secondary' onClick={(e) => showSearchHelp()}>Help</HelpButton>
+            <div className="searchbox">
+                <StyledSearchBoxInput
+                    {...{searchParams, showFilters, isFetching: true}}
+                />
+                <HelpButton variant='secondary' onClick={(e) => showSearchHelp()}>Help</HelpButton>
+            </div>
+            <div className="advanced-search">
+                <FilterLinkToggle type="button" onClick={(e) => toggleFilters(e)} aria-expanded={showFilters} >{showFilters ? "Hide Advanced Search" : "Show Advanced Search"}</FilterLinkToggle>
+            </div>
         </Container>
     );
 }


### PR DESCRIPTION
Replaces the left/right arrow icon that toggles search with a link underneath the search bar.
<img width="447" alt="Screenshot 2023-04-19 at 08 54 52" src="https://user-images.githubusercontent.com/77395846/232991062-71540db7-bd7d-4f23-b1a9-2c2a10f33988.png">

<img width="680" alt="Screenshot 2023-04-18 at 16 53 10" src="https://user-images.githubusercontent.com/77395846/232990912-55ff69f2-40cc-40b6-89ff-23031e250552.png">

## Summary of Changes
<!-- List or describe the changes you are making in this Pull Request -->

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [ ] Overall layout fills full width and height of viewport
- [ ] Pagination element doesn't overflow into other elements
