### PR TITLE
CSSTUDIO-1933: fix styling of ordered lists

### DIFF
--- a/src/components/shared/HtmlContent.js
+++ b/src/components/shared/HtmlContent.js
@@ -49,18 +49,29 @@ const Container = styled.div`
      *  with CSS; this supports six levels, which 
      *  should be enough 
      **/
-    ul,
-    li, li li li, li li li li li {
+    ul, 
+    ul li, 
+    ul li li li, 
+    ul li li li li li {
         list-style: disc inside;
     }
-    li li, li li li li, li li li li li li {
+    ul li li, 
+    ul li li li li, 
+    ul li li li li li li {
         list-style: circle inside;
     }
-    li li li, li li li li li {
+    ul li li li, 
+    ul li li li li li {
         list-style: square inside;
     }
-    ol {
+    ol,
+    ol li,
+    ol li li li {
         list-style: decimal inside;
+    }
+    ol li li,
+    ol li li li li {
+        list-style: lower-alpha inside;
     }
     ul, ol,
     li > ul,


### PR DESCRIPTION
## Summary of Changes
Fixes issue where ordered lists are styled as unordered lists (as bullet points). Was introduced by nested list CSS.

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [ ] Overall layout fills full width and height of viewport
- [ ] Pagination element doesn't overflow into other elements
