### PR TITLE
New endpoint to create log entry plus all attachments in single multipart request

### DIFF
--- a/src/components/App.test.js
+++ b/src/components/App.test.js
@@ -467,7 +467,7 @@ describe('Creating Log Entries', () => {
     
         // given the server creates the log entry successfully, responding with the id
         server.use(
-            rest.put('*/logs', (req, res, ctx) => {
+            rest.put('*/logs/multipart', (req, res, ctx) => {
                 return res(
                     ctx.json({id, title}),
                 );

--- a/src/components/EntryEditor/EmbedImageDialog.js
+++ b/src/components/EntryEditor/EmbedImageDialog.js
@@ -37,7 +37,7 @@ const ImageContainer = styled.div`
     }
 `
 
-const EmbedImageDialog = ({addEmbeddedImage, initialImage=null, setInitialImage, showEmbedImageDialog, setShowEmbedImageDialog}) => {
+const EmbedImageDialog = ({addEmbeddedImage, initialImage=null, setInitialImage, showEmbedImageDialog, setShowEmbedImageDialog, maxFileSizeMb}) => {
 
     const {control, setValue, watch, getValues, reset: resetForm} = useForm({
         mode: 'all',
@@ -146,6 +146,7 @@ const EmbedImageDialog = ({addEmbeddedImage, initialImage=null, setInitialImage,
                             id='embed-image-upload'
                             dragLabel='Drag Image Here'
                             browseLabel='Choose an Image or'
+                            maxFileSizeMb={maxFileSizeMb}
                         />
                     }
                     

--- a/src/components/EntryEditor/EntryEditor.js
+++ b/src/components/EntryEditor/EntryEditor.js
@@ -153,7 +153,6 @@ export const EntryEditor = ({
                 maxRequestSize: (attachments) => {
                     const total = attachments.map(it => it?.file?.size || 0).reduce((prev, curr) => curr + prev, 0);
                     const max = maxRequestSizeMb*1000000;
-                    console.log({validatingAttachments: attachments, total, max})
                     return total < max || `Attachments exceed total maximum upload size of ${maxRequestSizeMb}MB` 
                 },
                 maxFileSize: (attachments) => {
@@ -227,9 +226,6 @@ export const EntryEditor = ({
                 setMaxFileSizeMb(customization.defaultMaxFileSizeMb);
             })
     }, []);
-
-    console.log({maxRequestSizeMb, maxFileSizeMb, errors: formState?.errors?.attachments?.root})
-    console.log(formState.errors)
     
     /**
      * If currentLogEntry is defined, use it as a "template", i.e. user is replying to a log entry.

--- a/src/components/EntryEditor/EntryEditor.js
+++ b/src/components/EntryEditor/EntryEditor.js
@@ -170,7 +170,6 @@ export const EntryEditor = ({
     })
     // File input HTML element ref allows us to hide
     // the element and click it from e.g. a button
-    // const fileInputRef = useRef(null);
     const [initialImage, setInitialImage] = useState(null);
     const [createInProgress, setCreateInProgress] = useState(false);
     const [showEmbedImageDialog, setShowEmbedImageDialog] = useState(false);
@@ -537,7 +536,7 @@ export const EntryEditor = ({
                                 </div>
                             </DescriptionContainerFooter>
                         </DescriptionContainer>
-                        <DetachedLabel>Attachments</DetachedLabel>
+                        <DetachedLabel>Attachments <div style={{fontStyle: "italic", fontSize: "0.9em"}}>max size per file: {maxFileSizeMb}MB, max total size: {maxRequestSizeMb}MB</div></DetachedLabel>
                         <AttachmentsInputContainer>
                             <RenderedAttachmentsContainer hasAttachments={attachments && attachments.length > 0}>
                                 <DroppableFileUploadInput 
@@ -546,6 +545,7 @@ export const EntryEditor = ({
                                     dragLabel='Drag Here'
                                     browseLabel='Choose File(s) or'
                                     multiple
+                                    maxFileSizeMb={maxFileSizeMb}
                                 />
                                 { renderedAttachments }
                             </RenderedAttachmentsContainer>
@@ -586,6 +586,7 @@ export const EntryEditor = ({
                 addEmbeddedImage={addEmbeddedImage}
                 initialImage={initialImage}
                 setInitialImage={setInitialImage}
+                maxFileSizeMb={maxFileSizeMb}
             />
             <HtmlPreviewModal 
                 showHtmlPreview={showHtmlPreview}

--- a/src/components/EntryEditor/EntryEditor.js
+++ b/src/components/EntryEditor/EntryEditor.js
@@ -272,30 +272,6 @@ export const EntryEditor = ({
         updateProperty(index, copyOfProperty);
     }
 
-    /**
-     * Uploading multiple attachments must be done in a synchronous manner. Using axios.all()
-     * will upload only a single attachment, not sure why...
-     * @param {*} id 
-     * @returns 
-     */
-     const submitAttachmentsMulti = async (id) => {
-        for (let i = 0; i < attachments.length; i++) {
-            let formData = new FormData();
-            formData.append('file', attachments[i].file);
-            formData.append('id', attachments[i].id);
-            formData.append('filename', attachments[i].file.name);
-            await ologService.post(`/logs/attachments/${id}`, 
-                formData,
-                {
-                    headers: {
-                        'Content-Type': 'multipart/form-data',
-                        'Accept': 'application/json'
-                    },
-                    withCredentials: true
-                });
-        }
-    }
-
     const onSubmit = (formData) => {
 
         const promise = checkSession();
@@ -319,18 +295,29 @@ export const EntryEditor = ({
                         properties: formData.properties,
                         title: formData.title,
                         level: formData.entryType.value,
-                        description: formData.description
+                        description: formData.description,
+                        attachments: attachments
                     }
-                    let url = replyAction ? 
-                        `/logs?markup=commonmark&inReplyTo=${currentLogEntry.id}` :
-                        `/logs?markup=commonmark`;
-                    ologService.put(url, logEntry, { withCredentials: true, headers: ologClientInfoHeader() })
-                        .then(async res => {
-                            // console.log({created: res.data})
-                            if(attachments.length > 0){ // No need to call backend if there are no attachments.
-                                await submitAttachmentsMulti(res.data.id);
-                            }
+                    // This FormData object will contain both the log entry and all attached files, if any
+                    let multipartFormData = new FormData();
+                    // Append all files. Each is added with name "files", and that is actually OK
+                    for (let i = 0; i < attachments.length; i++) {
+                        multipartFormData.append("files", attachments[i].file, attachments[i].file.name);
+                    }
+                    // Log entry must be added as JSON blob, otherwise the content type cannot be set.
+                    multipartFormData.append("logEntry", new Blob([JSON.stringify(logEntry)], {type: 'application/json'}));
 
+                    // Need to set content type for the request "multipart/form-data"
+                    let requestHeaders = ologClientInfoHeader();
+                    requestHeaders["Content-Type"] = "multipart/form-data";
+                    requestHeaders["Accept"] = "application/json";
+                    
+                    let url = replyAction ? 
+                        `/logs/multipart?markup=commonmark&inReplyTo=${currentLogEntry.id}` :
+                        `/logs/multipart?markup=commonmark`;
+                    // Upload the full monty, i.e. log entry and all attachment files, in one single request.
+                    ologService.put(url, multipartFormData, { withCredentials: true, headers: requestHeaders})
+                        .then(async res => {
                             // Wait until the new log entry is available in the search results
                             await ologServiceWithRetry({
                                 method: 'GET',
@@ -343,7 +330,6 @@ export const EntryEditor = ({
                                     const found = retryRes?.data?.logs.find(it => `${it.id}` === `${res.data.id}`);
                                     const hasAllAttachments = found?.attachments?.length === attachments.length;
                                     const willRetry = !found || (found && !hasAllAttachments)
-                                    // console.log({time: new Date(), retryData: retryRes?.data?.logs, found, willRetry})
                                     return willRetry;
                                 },
                                 retryDelay: (count) => count*200
@@ -357,6 +343,9 @@ export const EntryEditor = ({
                         .catch(error => {
                             if(error.response && (error.response.status === 401 || error.response.status === 403)){
                                 alert('You are currently not authorized to create a log entry.')
+                            }
+                            else if(error.response && error.response.status === 413){ // 413 = payload too large
+                                alert(error.response.data); // Message set in data by server
                             }
                             else if(error.response && (error.response.status >= 500)){
                                 alert('Failed to create log entry.')

--- a/src/utils/customization.js
+++ b/src/utils/customization.js
@@ -72,7 +72,13 @@ let customization = {
     /**
      * Name of the cookie that stores the current search string
      */
-    searchPageParamsCookie: 'searchPageParams'
+    searchPageParamsCookie: 'searchPageParams',
+
+    /**
+     * Max total attachment upload size and individual file size (MB)
+     */
+    defaultMaxRequestSizeMb: 100,
+    defaultMaxFileSizeMb: 50
 }
 
 export default customization;


### PR DESCRIPTION
**NOTE: integration test requires new version of Olog service, available on branch CSSTUDIO-1818 in the service repo.**

## Summary of Changes
<!-- List or describe the changes you are making in this Pull Request -->

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [ ] Overall layout fills full width and height of viewport
- [ ] Pagination element doesn't overflow into other elements
