### PR TITLE
CSSTUDIO-2005: replace text inputs with mui

### DIFF
--- a/e2e/cypress/e2e/happy-paths.cy.js
+++ b/e2e/cypress/e2e/happy-paths.cy.js
@@ -16,7 +16,7 @@ describe('Happy Paths', () => {
     cy.visit('/');
 
     // Perform a search that should return the seed data (Should see 35 results from the seeding <30 seconds ago)
-    cy.findByRole('searchbox', {name: /Search/i}).clear().type('start=5 min{Enter}');
+    cy.findByRole('searchbox', {name: /Search Logs/i}).clear().type('start=5 min{Enter}');
 
     // Set the page size as expected
     cy.findByRole('textbox', {name: /hits per page/i}).clear().type('30{Enter}');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
+        "@mui/icons-material": "^5.14.8",
         "@mui/material": "^5.13.7",
         "@reduxjs/toolkit": "^1.9.1",
         "@testing-library/jest-dom": "^5.16.5",
@@ -2142,11 +2143,11 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
+      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2163,6 +2164,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/@babel/template": {
       "version": "7.20.7",
@@ -3544,6 +3550,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.14.8",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.14.8.tgz",
+      "integrity": "sha512-YXcReLydTuNWb1/PxduAH5LgnHNH6spSQBaA0JOz9HD4J+vwst0IanAQgsXy9KKCJSjCsHywE3DB8X+w/b4eeQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.10"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {
@@ -23628,11 +23659,18 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "@babel/runtime": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
+      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
       "requires": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+          "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+        }
       }
     },
     "@babel/runtime-corejs3": {
@@ -24543,6 +24581,14 @@
       "version": "5.13.7",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.13.7.tgz",
       "integrity": "sha512-/suIo4WoeL/OyO3KUsFVpdOmKiSAr6NpWXmQ4WLSxwKrTiha1FJxM6vwAki5W/5kR9WnVLw5E8JC4oHHsutT8w=="
+    },
+    "@mui/icons-material": {
+      "version": "5.14.8",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.14.8.tgz",
+      "integrity": "sha512-YXcReLydTuNWb1/PxduAH5LgnHNH6spSQBaA0JOz9HD4J+vwst0IanAQgsXy9KKCJSjCsHywE3DB8X+w/b4eeQ==",
+      "requires": {
+        "@babel/runtime": "^7.22.10"
+      }
     },
     "@mui/material": {
       "version": "5.13.7",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.14.8",
     "@mui/material": "^5.13.7",
     "@reduxjs/toolkit": "^1.9.1",
     "@testing-library/jest-dom": "^5.16.5",

--- a/src/components/EntryEditor/EmbedImageDialog.js
+++ b/src/components/EntryEditor/EmbedImageDialog.js
@@ -23,12 +23,10 @@ import TextInput from 'components/shared/input/TextInput';
 import { DroppableFileUploadInput } from 'components/shared/input/FileInput';
 import { useState } from 'react';
 import Button from 'components/shared/Button';
-import styled from 'styled-components';
+import styledStyledComponents from 'styled-components';
+import { Stack } from '@mui/material';
 
-const Form = styled.form`
-`
-
-const ImageContainer = styled.div`
+const ImageContainer = styledStyledComponents.div`
     max-height: 50vh;
     max-width: 50vw;
     & img {
@@ -130,66 +128,69 @@ const EmbedImageDialog = ({addEmbeddedImage, initialImage=null, setInitialImage,
         <Modal show={showEmbedImageDialog} 
             onClose={handleClose}
         >
-            <Form 
+            <Stack
+                component="form" 
                 onSubmit={handleSubmit}
+                gap={1}
             >
                 <Header closeButton onClose={handleClose}>
                     <Title>Add Embedded Image</Title>
                 </Header>
                 <Body>
-                    {imageAttachment 
-                    ?   <ImageContainer>
-                            <img src={URL.createObjectURL(imageAttachment)} alt={`preview of ${imageAttachment.name}`} />
-                        </ImageContainer>
-                    :   <DroppableFileUploadInput 
-                            onFileChanged={onFileChanged}
-                            id='embed-image-upload'
-                            dragLabel='Drag Image Here'
-                            browseLabel='Choose an Image or'
-                            maxFileSizeMb={maxFileSizeMb}
+                    <Stack gap={2} >
+                        {imageAttachment 
+                        ?   <ImageContainer>
+                                <img src={URL.createObjectURL(imageAttachment)} alt={`preview of ${imageAttachment.name}`} />
+                            </ImageContainer>
+                        :   <DroppableFileUploadInput 
+                                onFileChanged={onFileChanged}
+                                id='embed-image-upload'
+                                dragLabel='Drag Image Here'
+                                browseLabel='Choose an Image or'
+                                maxFileSizeMb={maxFileSizeMb}
+                            />
+                        }
+                        
+                        <TextInput 
+                            name='scalingFactor'
+                            label='Scaling Factor'
+                            control={control}
+                            defaultValue='1.0'
+                            rules={{
+                                validate: {
+                                    isCorrectRange: val => scalingFactorIsValid(val) || 'Scaling factor must be between 0 and 1'
+                                }
+                            }}
                         />
-                    }
-                    
-                    <TextInput 
-                        name='scalingFactor'
-                        label='Scaling Factor'
-                        control={control}
-                        defaultValue='1.0'
-                        rules={{
-                            validate: {
-                                isCorrectRange: val => scalingFactorIsValid(val) || 'Scaling factor must be between 0 and 1'
-                            }
-                        }}
-                    />
-                    <TextInput 
-                        name='imageWidth'
-                        label='Width'
-                        control={control}
-                        defaultValue='0.0'
-                        rules={{
-                            validate: {
-                                isPositive: val => dimensionIsValid(val) || 'Width must be a positive number'
-                            }
-                        }}
-                    />
-                    <TextInput 
-                        name='imageHeight'
-                        label='Height'
-                        control={control}
-                        defaultValue='0.0'
-                        rules={{
-                            validate: {
-                                isPositive: val => dimensionIsValid(val) || 'Height must be a positive number'
-                            }
-                        }}
-                    />
-                    
+                        <TextInput 
+                            name='imageWidth'
+                            label='Width'
+                            control={control}
+                            defaultValue='0.0'
+                            rules={{
+                                validate: {
+                                    isPositive: val => dimensionIsValid(val) || 'Width must be a positive number'
+                                }
+                            }}
+                        />
+                        <TextInput 
+                            name='imageHeight'
+                            label='Height'
+                            control={control}
+                            defaultValue='0.0'
+                            rules={{
+                                validate: {
+                                    isPositive: val => dimensionIsValid(val) || 'Height must be a positive number'
+                                }
+                            }}
+                        />
+                    </Stack>
                 </Body>
                 <Footer>
                     <Button variant="secondary" onClick={handleClose}>Cancel</Button>
                     <Button variant="primary" disabled={imageAttachment === null} onClick={handleSubmit}>Confirm Embed</Button>
                 </Footer>
-            </Form>
+            </Stack>
         </Modal>
     )
     

--- a/src/components/EntryEditor/EntryEditor.js
+++ b/src/components/EntryEditor/EntryEditor.js
@@ -45,6 +45,7 @@ import ExternalLink from 'components/shared/ExternalLink';
 import { APP_BASE_URL } from 'constants';
 import HtmlPreviewModal from './HtmlPreviewModal';
 import ErrorMessage from 'components/shared/input/ErrorMessage';
+import { Box, Stack } from '@mui/material';
 
 const Container = styled.div`
     padding: 1rem 0.5rem;
@@ -62,25 +63,7 @@ const Form = styled.form`
     gap: 0.5rem;
 `
 
-const DescriptionContainer = styled.div`
-    display: flex;
-    flex-direction: column;
-    padding-bottom: 1rem;
-`
-
 const DescriptionTextInput = styled(TextInput)`
-`
-
-const DescriptionContainerFooter = styled.div`
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0 0.5rem;
-
-    & div {
-        display: flex;
-        gap: 1rem;
-    }
 `
 
 const ButtonContent = styled.div`
@@ -480,24 +463,24 @@ export const EntryEditor = ({
                                 }
                             }}
                         />
-                        <DescriptionContainer>
+                        <Stack gap={1}>
 
                             <DescriptionTextInput 
                                 name='description'
                                 label='Description'
                                 control={control}
                                 defaultValue=''
-                                textArea
-                                rows={10}
+                                multiline
+                                minRows={10}
                                 onPaste={handlePaste}
                             />
-                            <DescriptionContainerFooter>
-                                <div>
+                            <Stack direction="row" justifyContent="space-between">
+                                <Box>
                                     <ExternalLink href={`${APP_BASE_URL}/help/CommonmarkCheatsheet`} >
                                         <FaMarkdown />CommonMark Formatting Help
                                     </ExternalLink>
-                                </div>
-                                <div>
+                                </Box>
+                                <Stack direction="row">
                                     <Button variant="secondary" size="sm" style={{marginLeft: "5px"}}
                                             onClick={(e) => {
                                                 e.preventDefault();
@@ -514,9 +497,9 @@ export const EntryEditor = ({
                                             }}>
                                         Preview
                                     </Button>
-                                </div>
-                            </DescriptionContainerFooter>
-                        </DescriptionContainer>
+                                </Stack>
+                            </Stack>
+                        </Stack>
                         <DetachedLabel>Attachments <div style={{fontStyle: "italic", fontSize: "0.9em"}}>max size per file: {maxFileSizeMb}MB, max total size: {maxRequestSizeMb}MB</div></DetachedLabel>
                         <AttachmentsInputContainer>
                             <RenderedAttachmentsContainer hasAttachments={attachments && attachments.length > 0}>

--- a/src/components/Filters/Filters.js
+++ b/src/components/Filters/Filters.js
@@ -24,16 +24,8 @@ import Collapse from './Collapse';
 import TextInput from 'components/shared/input/TextInput';
 import WizardDateInput from 'components/shared/input/WizardDateInput';
 import RadioInput from 'components/shared/input/RadioInput';
-import styled from 'styled-components';
 import Button from 'components/shared/Button';
 import { Stack } from '@mui/material';
-
-const Form = styled.form`
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    height: 100%;
-`
 
 /**
  * Component holding search criteria elements, i.e.
@@ -85,7 +77,12 @@ const Filters = ({showFilters, logbooks, tags, className}) => {
         <Collapse show={showFilters} onExiting={handleSubmit(onSubmit)} >
             <Stack gap={0.5} padding={1} className={className} sx={{overflow: "auto"}} >
                 <h2 id="advanced-search">Advanced Search</h2>
-                <Form onSubmit={handleSubmit(onSubmit)} aria-labelledby='advanced-search' role='search' >
+                <Stack 
+                    component="form" 
+                    onSubmit={handleSubmit(onSubmit)}
+                    aria-labelledby='advanced-search' role='search' 
+                    gap={1}
+                >
                     {/* Hidden button handles submit-on-enter automatically */}
                     <Button type='submit' hidden >Submit</Button>
                     <TextInput 
@@ -188,7 +185,7 @@ const Filters = ({showFilters, logbooks, tags, className}) => {
                         control={control}
                         defaultValue=''
                     />
-                </Form>
+                </Stack>
             </Stack>
         </Collapse>
     );

--- a/src/components/LogEntriesView/index.js
+++ b/src/components/LogEntriesView/index.js
@@ -27,11 +27,13 @@ import { updateSearchPageParams } from 'features/searchPageParamsReducer';
 import { useSearchLogsQuery } from 'services/ologApi';
 import { updateCurrentLogEntry } from 'features/currentLogEntryReducer';
 import ServiceErrorBanner from 'components/ErrorBanner';
-import styled from 'styled-components';
+import styledComponentsStyled from 'styled-components';
 import Filters from 'components/Filters';
 import { desktop, mobile } from 'config/media';
+import { styled } from '@mui/material';
+import { grey } from '@mui/material/colors';
 
-const ContentContainer = styled.div`
+const ContentContainer = styledComponentsStyled.div`
     height: 100%;
     display: flex;
     gap: 0.5rem;
@@ -44,18 +46,17 @@ const ContentContainer = styled.div`
     `)}
 `
 
-const StyledFilters = styled(Filters)`
-    flex: 0 0 20%;
-    border: 1px solid ${({theme}) => theme.colors.light};
-    border-radius: 5px;
+const StyledFilters = styled(Filters)(({theme}) => ({
+    flex: "0 0 20%",
+    border: `1px solid ${grey[300]}`,
+    borderRadius: "5px",
+    [theme.breakpoints.down("sm")]: {
+        order: 9,
+        width: "100%"
+    }
+}));
 
-    ${mobile(`
-        order: 9;
-        width: 100%;
-    `)}
-`
-
-const StyledSearchResultList = styled(SearchResultList)`
+const StyledSearchResultList = styledComponentsStyled(SearchResultList)`
     flex: 0 0 30%;
     border: 1px solid ${({theme}) => theme.colors.light};
     border-radius: 5px;
@@ -66,7 +67,7 @@ const StyledSearchResultList = styled(SearchResultList)`
     `)}
 `
 
-const LogDetailsContainer = styled.div`
+const LogDetailsContainer = styledComponentsStyled.div`
     display: flex;
     flex-direction: column;
     flex: 1 0 0;

--- a/src/components/LoginLogout/LoginDialog.js
+++ b/src/components/LoginLogout/LoginDialog.js
@@ -23,10 +23,8 @@ import ologService from 'api/olog-service';
 import { useForm } from 'react-hook-form';
 import TextInput from 'components/shared/input/TextInput';
 import ErrorMessage from 'components/shared/input/ErrorMessage';
-import styled from 'styled-components';
 import Submit from 'components/shared/input/Submit';
-
-const Form = styled.form``;
+import { Stack } from '@mui/material';
 
 const LoginDialog = ({setUserData, setShowLogin, loginDialogVisible}) => {
 
@@ -74,7 +72,7 @@ const LoginDialog = ({setUserData, setShowLogin, loginDialogVisible}) => {
         <Title>Sign In</Title>
       </Header>
       <Body>
-        <Form onSubmit={handleSubmit(login)}>
+        <Stack component="form" onSubmit={handleSubmit(login)} gap={1} marginY={2}>
           {/* Hidden button handles submit-on-enter automatically */}
           <Submit hidden />
           <TextInput 
@@ -88,10 +86,10 @@ const LoginDialog = ({setUserData, setShowLogin, loginDialogVisible}) => {
             label='Password'
             control={control}
             defaultValue=''
-            password
+            inputProps={{type: "password"}}
           />
           <ErrorMessage error={loginError} />
-        </Form>
+        </Stack>
       </Body>
       <Footer>
         <Button variant="primary" type="submit" onClick={handleSubmit(login)}>

--- a/src/components/SearchResult/PageSizeInput.js
+++ b/src/components/SearchResult/PageSizeInput.js
@@ -1,6 +1,7 @@
 import { StyledLabeledTextInput } from "components/shared/input/TextInput";
 import { useState } from "react";
 
+// TODO: Remove StyledLabeledTextInput once this is replaced!
 const PageSizeInput = ({initialValue=0, onValidChange=() => {}}) => {
 
     const [pageSize, setPageSize] = useState(initialValue);

--- a/src/components/SearchResult/SearchBox.js
+++ b/src/components/SearchResult/SearchBox.js
@@ -16,69 +16,34 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-import styled from "styled-components"
-import Button from "components/shared/Button"
 import SearchBoxInput from "./SearchBoxInput"
-
-const Container = styled.div`
-    width: 100%;
-    padding: 0.25rem 0.5rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    & > .searchbox {
-        display: flex;
-        gap: 0.25rem; 
-    }
-    & .advanced-search {
-        display: flex;
-        justify-content: flex-end;
-    }
-`
-
-const StyledSearchBoxInput = styled(SearchBoxInput)`
-    display: block;
-    flex-grow: 1;
-`
-
-const FilterLinkToggle = styled.button`
-    padding: 0;
-    border: none;
-    background: none;
-    color: blue;
-    font-style: italic;
-    &:hover {
-        text-decoration: underline;
-        cursor: pointer;
-    }
-`
-
-const HelpButton = styled(Button)`
-    padding: 0 1rem;
-`
+import { Link, Stack } from "@mui/material"
 
 const SearchBox = ({searchParams, showFilters, setShowFilters, className}) => {
 
     const toggleFilters = (e) => {
         setShowFilters(!showFilters)
     }
-
-    const showSearchHelp = () => {
-        window.open(`${process.env.REACT_APP_BASE_URL}/SearchHelp_en.html`, '_blank');
-    }
     
     return (
-        <Container className={className} >
-            <div className="searchbox">
-                <StyledSearchBoxInput
-                    {...{searchParams, showFilters, isFetching: true}}
-                />
-                <HelpButton variant='secondary' onClick={(e) => showSearchHelp()}>Help</HelpButton>
-            </div>
-            <div className="advanced-search">
-                <FilterLinkToggle type="button" onClick={(e) => toggleFilters(e)} aria-expanded={showFilters} >{showFilters ? "Hide Advanced Search" : "Show Advanced Search"}</FilterLinkToggle>
-            </div>
-        </Container>
+        <Stack gap={0.5} padding={1}>
+            <SearchBoxInput
+                {...{searchParams, showFilters, isFetching: true}}
+            />
+            <Link 
+                component="button"
+                type="button"
+                onClick={(e) => toggleFilters(e)} 
+                aria-expanded={showFilters}
+                sx={{
+                    fontStyle: "italic",
+                    width: "max-content",
+                    alignSelf: "flex-end"
+                }}
+            >
+                {showFilters ? "Hide Advanced Search" : "Show Advanced Search"}
+            </Link>
+        </Stack>
     );
 }
 

--- a/src/components/SearchResult/SearchBoxInput.js
+++ b/src/components/SearchResult/SearchBoxInput.js
@@ -22,10 +22,12 @@ import {useState} from 'react';
 import {searchParamsToQueryString, queryStringToSearchParameters} from 'utils/searchParams';
 import { useDispatch } from "react-redux";
 import { forceUpdateSearchParams } from "features/searchParamsReducer";
-import { StyledTextInput } from "components/shared/input/TextInput";
-import VisuallyHiddenText from "components/shared/VisuallyHiddenText";
+import { InputAdornment, Link, OutlinedInput, styled } from "@mui/material";
+import HelpIcon from '@mui/icons-material/Help';
 
-const SearchBoxInput = ({searchParams, showFilters, className}) => {
+const label = "Search Logs";
+
+const SearchBoxInput = styled(({searchParams, showFilters, className}) => {
 
     const [searchString, setSearchString] = useState("");
     const dispatch = useDispatch();
@@ -51,21 +53,36 @@ const SearchBoxInput = ({searchParams, showFilters, className}) => {
     }
 
     return (
-        <>
-            <VisuallyHiddenText><label htmlFor="search">Search</label></VisuallyHiddenText>
-            <StyledTextInput size="sm" 
-                name='search'
-                type='search'
-                disabled={showFilters}
-                placeholder="No search string"
-                style={{fontSize: "12px"}}
-                value={searchString}
-                onChange={(e) => onChange(e)}
-                onKeyDown={onKeyDown}
-                className={className}
-            />
-        </>
+        <OutlinedInput 
+            id="search"
+            disabled={showFilters}
+            placeholder="No search string"
+            value={searchString}
+            onChange={(e) => onChange(e)}
+            onKeyDown={onKeyDown}
+            inputProps={{
+                "type": "search",
+                
+                "aria-label": label
+            }}
+            endAdornment={
+                <InputAdornment position="end">
+                    <Link 
+                        href={`${process.env.REACT_APP_BASE_URL}/SearchHelp_en.html`} 
+                        target="_blank" 
+                        aria-label="Logbook Search Help Reference, opens in new tab"
+                        sx={{ 
+                            display: "flex",
+                            alignItems: "center"
+                        }}
+                    >
+                        <HelpIcon color="primary" />
+                    </Link>
+                </InputAdornment>
+            }
+            className={className}           
+        />
     );
-}
+})({});
 
 export default SearchBoxInput;

--- a/src/components/shared/input/TextInput.js
+++ b/src/components/shared/input/TextInput.js
@@ -1,16 +1,18 @@
 import React from "react";
 import { useController } from "react-hook-form";
-import styled from "styled-components"
+import styledComponentsStyled from "styled-components"
 import LabeledInput from "./LabeledInput"
+import { TextField } from "@mui/material";
+import { styled } from "@mui/material/styles";
 
-export const StyledInput = styled.input`
+export const StyledInput = styledComponentsStyled.input`
     width: 100%;
     padding: 0.5rem 1rem;
     border: solid 1px ${({theme}) => theme.colors.light};
     border-radius: 5px;
 `
 
-export const StyledTextArea = styled.textarea`
+export const StyledTextArea = styledComponentsStyled.textarea`
     width: 100%;
     padding: 0.5rem 1rem;
     border: solid 1px ${({theme}) => theme.colors.light};
@@ -57,26 +59,21 @@ export const StyledLabeledTextInput = React.forwardRef(({name, label, message, c
     );
 });
 
-export const TextInput = ({name, label, control, rules, defaultValue, className, textArea=false, rows=3, password=false, inlineLabel, ...props}) => {
+export const TextInput = styled(({name, label, control, rules, defaultValue, className, ...props}) => {
     
     const {field, fieldState} = useController({name, control, rules, defaultValue});
 
-    return <StyledLabeledTextInput 
-        {...{name, 
-            label, 
-            message: fieldState?.error?.message, 
-            className, 
-            textArea, 
-            rows, 
-            password, 
-            ref: field.ref, 
-            value:field.value, 
-            onChange:field.onChange,
-            inlineLabel,
-        }}
-        {...props}
-    />
+    return (
+        <TextField 
+            id={name}
+            label={label}
+            helperText={fieldState?.error?.message}
+            error={fieldState?.error}
+            {...field}
+            {...props}
+        />
+    );
     
-}
+})({});
 
 export default TextInput;


### PR DESCRIPTION
## Summary of Changes

- Replaces implementation of text inputs with MUI text inputs
- Updates search box to leverage adorned inputs; increases space available to read searchbar text

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [ ] Overall layout fills full width and height of viewport
- [ ] Pagination element doesn't overflow into other elements
