### PR TITLE
CSSTUDIO-2033: fix TextInput crash on bad ref focus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Olog",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "Olog",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
@@ -23,7 +23,7 @@
         "react-datetime-picker": "^3.0.4",
         "react-dom": "^18.1.0",
         "react-focus-lock": "^2.9.2",
-        "react-hook-form": "^7.38.0",
+        "react-hook-form": "^7.46.1",
         "react-hook-form-persist": "^3.0.0",
         "react-icons": "^3.10.0",
         "react-moment": "^1.1.2",
@@ -18252,9 +18252,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.38.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.38.0.tgz",
-      "integrity": "sha512-gxWW1kMeru9xR1GoR+Iw4hA+JBOM3SHfr4DWCUKY0xc7Vv1MLsF109oHtBeWl9shcyPFx67KHru44DheN0XY5A==",
+      "version": "7.46.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.46.1.tgz",
+      "integrity": "sha512-0GfI31LRTBd5tqbXMGXT1Rdsv3rnvy0FjEk8Gn9/4tp6+s77T7DPZuGEpBRXOauL+NhyGT5iaXzdIM2R6F/E+w==",
       "engines": {
         "node": ">=12.22.0"
       },
@@ -35225,9 +35225,9 @@
       }
     },
     "react-hook-form": {
-      "version": "7.38.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.38.0.tgz",
-      "integrity": "sha512-gxWW1kMeru9xR1GoR+Iw4hA+JBOM3SHfr4DWCUKY0xc7Vv1MLsF109oHtBeWl9shcyPFx67KHru44DheN0XY5A==",
+      "version": "7.46.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.46.1.tgz",
+      "integrity": "sha512-0GfI31LRTBd5tqbXMGXT1Rdsv3rnvy0FjEk8Gn9/4tp6+s77T7DPZuGEpBRXOauL+NhyGT5iaXzdIM2R6F/E+w==",
       "requires": {}
     },
     "react-hook-form-persist": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react-datetime-picker": "^3.0.4",
     "react-dom": "^18.1.0",
     "react-focus-lock": "^2.9.2",
-    "react-hook-form": "^7.38.0",
+    "react-hook-form": "^7.46.1",
     "react-hook-form-persist": "^3.0.0",
     "react-icons": "^3.10.0",
     "react-moment": "^1.1.2",

--- a/src/components/Banner/Banner.js
+++ b/src/components/Banner/Banner.js
@@ -103,7 +103,7 @@ export const Banner = ({userData, setUserData, showLogin, setShowLogin, showLogo
         <NavFooter>
           <li>
             <MuiButton onClick={handleClick} variant="contained" >
-              {userData.userName ? userData.userName : 'Sign In'}
+              {userData?.userName ? userData.userName : 'Sign In'}
             </MuiButton>
           </li>
         </NavFooter>

--- a/src/components/shared/input/TextInput.js
+++ b/src/components/shared/input/TextInput.js
@@ -61,7 +61,7 @@ export const StyledLabeledTextInput = React.forwardRef(({name, label, message, c
 
 export const TextInput = styled(({name, label, control, rules, defaultValue, className, ...props}) => {
     
-    const {field, fieldState} = useController({name, control, rules, defaultValue});
+    const {field: {ref, ...field}, fieldState} = useController({name, control, rules, defaultValue});
 
     return (
         <TextField 
@@ -69,6 +69,7 @@ export const TextInput = styled(({name, label, control, rules, defaultValue, cla
             label={label}
             helperText={fieldState?.error?.message}
             error={fieldState?.error}
+            inputRef={field.ref}
             {...field}
             {...props}
         />


### PR DESCRIPTION
## Summary of Changes

- fixes crash that can be invoked by clicking sign-in, cancelling (or signing-in), then your profile button (cause was incorrectly mapped ref to MUI TextField)
- updates version of react-hook-form
- updates package version in package-lock file

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [ ] Overall layout fills full width and height of viewport
- [ ] Pagination element doesn't overflow into other elements
