### PR TITLE
CSSTUDIO-2065: add entryType to filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ Available:
 * List view for search results.
 * Properties editor.
 * HTML preview of log entry, including embedded images.
+* Editing log entries
 
 Backlog:
 * Localization.
 
 ## Site customization
 
-The file `customization.js` contains customizable items. Please review its contents and adjust to your needs.
+The file `src/config/customization.js` contains customizable items. Please review its contents and adjust to your needs.
 
 ## Development 
 
@@ -108,7 +109,7 @@ End-to-end testing is run via [Cypress](https://www.cypress.io/), and is provide
 
 You can run tests interactively (this will open cypress, a browser, etc. and execute the tests live) or you can run them headlessly one-time via docker compose (videos of the tests are made available in the `cypress/videos` and `cypress/screenshots` folders, and is ignored by git)
 
-Run end-to-end tests interactively:
+Run end-to-end tests interactively (opens Cypress's test runner in a new window):
 
 ```
 # (start the backend services in one console)
@@ -130,9 +131,11 @@ The below instructions apply to a deployment scenario where a web server hosts t
 
 1. Review the file `customization.js`. It contains a few values defining text resources that might differ between sites. If you need different values, update according to your needs, but please do not commit the changes.
 
-1. Build the deployment artifacts:\
-   `>REACT_APP_BASE_URL=Olog/ npm run-script build`\
-   Note that the `REACT_APP_BASE_URL=Olog/` portion of the command is needed in order to override whatever value in the `.env` file. The actual value will depend on 
+1. Build the deployment artifacts (`REACT_APP_*` variables must be set during build; they are compile-time variables):
+   ```
+   REACT_APP_BASE_URL=Olog/ npm run-script build
+   ``` 
+   Note that setting `REACT_APP_BASE_URL` is needed in order to override whatever value in the `.env` file. The actual value will depend on 
    how the web application is deployed.
    
    This will generate files in the `build` directory, all of which must be copied to the target web server. Publish the web client resource under the root context, i.e. the URL `http://<host>/` shall resolve to the file `index.html` found in the build output.

--- a/src/api/ologApi.js
+++ b/src/api/ologApi.js
@@ -20,6 +20,9 @@ export const removeEmptyKeys = (obj, exceptions=[]) => {
                 delete copy[key]
             }
         }
+        if(val === undefined || val === null) {
+            delete copy[key]
+        }
     }
     return copy;
 }

--- a/src/api/ologApi.test.js
+++ b/src/api/ologApi.test.js
@@ -1,0 +1,59 @@
+const { removeEmptyKeys } = require("./ologApi");
+
+test("Empty lists are removed", () => {
+
+    const result = removeEmptyKeys({
+        foo: ["bar"],
+        baz: []
+    })
+
+    expect(result).toEqual({
+        foo: ["bar"]
+    })
+
+});
+
+test("empty strings are removed", () => {
+
+    const result = removeEmptyKeys({
+        foo: "bar",
+        baz: ""
+    })
+
+    expect(result).toEqual({
+        foo: "bar"
+    })
+    
+});
+
+test("null and undefined values are removed", () => {
+
+    const result = removeEmptyKeys({
+        foo: "bar",
+        baz: null,
+        phooey: undefined
+    })
+
+    expect(result).toEqual({
+        foo: "bar"
+    })
+
+});
+
+test("exceptions are excluded", () => {
+
+    const result = removeEmptyKeys({
+        foo: "bar",
+        baz: null,
+        phooey: undefined,
+        whamo: []
+    }, ["baz", "phooey", "whamo"]);
+
+    expect(result).toEqual({
+        foo: "bar",
+        baz: null,
+        phooey: undefined,
+        whamo: []
+    })
+
+});

--- a/src/components/Filters/Filters.js
+++ b/src/components/Filters/Filters.js
@@ -27,6 +27,7 @@ import { Button, Stack } from '@mui/material';
 import customization from 'config/customization';
 import TagsMultiSelect from 'components/shared/input/managed/TagsMultiSelect';
 import LogbooksMultiSelect from 'components/shared/input/managed/LogbooksMultiSelect';
+import EntryTypeSelect from 'components/shared/input/managed/EntryTypeSelect';
 
 /**
  * Component holding search criteria elements, i.e.
@@ -98,6 +99,10 @@ const Filters = ({showFilters, className}) => {
                         label='Text'
                         control={control}
                         defaultValue=''
+                    />
+                    <EntryTypeSelect 
+                        control={control}
+                        onChange={(field, value) => onSearchParamFieldValueChanged(field, value, true)}
                     />
                     <LogbooksMultiSelect 
                         control={control}

--- a/src/components/log/CreateLog/CreateLog.js
+++ b/src/components/log/CreateLog/CreateLog.js
@@ -42,7 +42,7 @@ const CreateLog = ({isAuthenticated}) => {
             tags: formData.tags,
             properties: formData.properties,
             title: formData.title,
-            level: formData.entryType,
+            level: formData.level,
             description: formData.description,
             attachments: formData.attachments
         }

--- a/src/components/log/EditLog/EditLog.js
+++ b/src/components/log/EditLog/EditLog.js
@@ -15,7 +15,7 @@ const EditLog = ({log, isAuthenticated}) => {
         defaultValues: {
             attachments: []
         },
-        values: {...log, entryType: log.level}
+        values: {...log}
     });
 
     const onSubmit = (formData) => {
@@ -41,7 +41,7 @@ const EditLog = ({log, isAuthenticated}) => {
                 tags: formData.tags,
                 properties: formData.properties,
                 title: formData.title,
-                level: formData.entryType,
+                level: formData.level,
                 description: formData.description
             },
             { withCredentials: true, headers: requestHeaders}

--- a/src/components/log/EditLog/EditLog.js
+++ b/src/components/log/EditLog/EditLog.js
@@ -15,7 +15,7 @@ const EditLog = ({log, isAuthenticated}) => {
         defaultValues: {
             attachments: []
         },
-        values: {...log}
+        values: {...log, description: log.source}
     });
 
     const onSubmit = (formData) => {

--- a/src/components/log/EntryEditor/Description/Description.js
+++ b/src/components/log/EntryEditor/Description/Description.js
@@ -44,13 +44,13 @@ const Description = ({form, attachmentsDisabled }) => {
         rules: {
             validate: {
                 maxRequestSize: (attachments) => {
-                    const total = attachments.map(it => it?.file?.size || 0).reduce((prev, curr) => curr + prev, 0);
+                    const total = attachments?.map(it => it?.file?.size || 0)?.reduce((prev, curr) => curr + prev, 0);
                     const max = maxRequestSizeMb*1000000;
                     return total < max || `Attachments exceed total maximum upload size of ${maxRequestSizeMb}MB` 
                 },
                 maxFileSize: (attachments) => {
                     const max = maxFileSizeMb*1000000;
-                    const results = attachments.filter(it => it?.file?.size > max).map(it => it?.file?.name);
+                    const results = attachments?.filter(it => it?.file?.size > max)?.map(it => it?.file?.name);
                     return results.length === 0 || `Attachments exceed max filesize (${maxFileSizeMb}MB): ${results}`
                 }
             }
@@ -136,7 +136,7 @@ const Description = ({form, attachmentsDisabled }) => {
     /**
      * If attachments are present, creates a wrapper containing an array of Attachment components
      */
-    const renderedAttachments = attachments.map((attachment, index) => {
+    const renderedAttachments = attachments?.map((attachment, index) => {
         return  <Attachment 
                     key={index} 
                     attachment={attachment} 
@@ -214,7 +214,7 @@ const Description = ({form, attachmentsDisabled }) => {
                 showHtmlPreview={showHtmlPreview}
                 setShowHtmlPreview={setShowHtmlPreview}
                 commonmarkSrc={getValues('description')}
-                attachedFiles={attachments}
+                attachedFiles={attachments ?? []}
             />
         </Stack>
     );

--- a/src/components/log/EntryEditor/EntryEditor.js
+++ b/src/components/log/EntryEditor/EntryEditor.js
@@ -16,13 +16,11 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 import Modal from 'components/shared/Modal';
-import customization from 'config/customization';
 import PropertyEditor from './PropertyEditor';
 import PropertySelector from './PropertySelector';
 import { useState } from 'react';
 import { useEffect } from 'react';
 import { useGetPropertiesQuery } from 'api/ologApi';
-import MultiSelect from 'components/shared/input/MultiSelect';
 import { useFieldArray } from 'react-hook-form';
 import TextInput from 'components/shared/input/TextInput';
 import styled from 'styled-components';
@@ -32,6 +30,7 @@ import AddIcon from '@mui/icons-material/Add';
 import Description from './Description';
 import LogbooksMultiSelect from 'components/shared/input/managed/LogbooksMultiSelect';
 import TagsMultiSelect from 'components/shared/input/managed/TagsMultiSelect';
+import EntryTypeSelect from 'components/shared/input/managed/EntryTypeSelect';
 
 const Container = styled.div`
     padding: 1rem 0.5rem;
@@ -134,12 +133,15 @@ export const EntryEditor = ({form, title, onSubmit, submitDisabled, attachmentsD
                     <TagsMultiSelect 
                         control={control}
                     />
-                    <MultiSelect 
+                    {/* <MultiSelect 
                         name='entryType'
                         label='Entry Type'
                         control={control}
                         defaultValue={customization.defaultLevel}
                         options={customization.levelValues}
+                    /> */}
+                    <EntryTypeSelect 
+                        control={control}
                     />
                     <TextInput 
                         name='title'

--- a/src/components/log/ReplyLog/ReplyLog.js
+++ b/src/components/log/ReplyLog/ReplyLog.js
@@ -24,7 +24,7 @@ const ReplyLog = ({log, isAuthenticated}) => {
              */
             logbooks: log?.logbooks ?? [],
             tags: log?.tags ?? [],
-            entryType: customization.defaultLevel,
+            level: customization.defaultLevel,
             title: log?.title,
         }
     });
@@ -42,7 +42,7 @@ const ReplyLog = ({log, isAuthenticated}) => {
             tags: formData.tags,
             properties: formData.properties,
             title: formData.title,
-            level: formData.entryType,
+            level: formData.level,
             description: formData.description,
             attachments: formData.attachments
         }

--- a/src/components/shared/input/managed/EntryTypeSelect.js
+++ b/src/components/shared/input/managed/EntryTypeSelect.js
@@ -9,7 +9,7 @@ const EntryTypeSelect = styled(({control, className, ...props}) => {
         <MultiSelect 
             className={className}
             name='level'
-            label='Entry Type'
+            label={customization.level ?? "Entry Type"}
             control={control}
             defaultValue={customization.defaultLevel}
             options={customization.levelValues}

--- a/src/components/shared/input/managed/EntryTypeSelect.js
+++ b/src/components/shared/input/managed/EntryTypeSelect.js
@@ -1,0 +1,21 @@
+import React from "react";
+import MultiSelect from "../MultiSelect";
+import { styled } from "@mui/material";
+import customization from "config/customization";
+
+const EntryTypeSelect = styled(({control, className, ...props}) => {
+
+    return (
+        <MultiSelect 
+            className={className}
+            name='level'
+            label='Entry Type'
+            control={control}
+            defaultValue={customization.defaultLevel}
+            options={customization.levelValues}
+            {...props}
+        />
+    )
+})({});
+
+export default EntryTypeSelect;


### PR DESCRIPTION
## Summary of Changes

- adds EntryType dropdown to filters, like in the phoebus client
- adds test for some utilities


<img width="524" alt="Screenshot 2023-11-20 at 10 11 25" src="https://github.com/Olog/phoebus-olog-web-client/assets/77395846/5b980c0e-d8fa-4c6e-ad52-b5cb2045db79">

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [ ] Overall layout fills full width and height of viewport
- [ ] Pagination element doesn't overflow into other elements
