### PR TITLE
CSSTUDIO-1983: migrate single and group entry views to mui

### DIFF
--- a/src/components/LogDetails/GroupHeader.js
+++ b/src/components/LogDetails/GroupHeader.js
@@ -15,22 +15,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
- import React from 'react';
-import { FaPaperclip } from 'react-icons/fa';
-import styled from 'styled-components';
+import React from 'react';
 import FormattedDate from 'components/shared/FormattedDate';
- 
-const Container = styled.div`
-    display: flex;
-    background-color: ${({theme}) => theme.colors.light};
-    font-size: 1.2rem;
-`
-
-const Right = styled.div`
-    display: flex;
-    gap: 0.5rem;
-    margin-left: auto;
-`
+import { Box, Stack, Typography } from '@mui/material';
+import AttachFileIcon from '@mui/icons-material/AttachFile';
 
  /**
   * Simple component rendering a header item when showing a merged view of 
@@ -41,15 +29,27 @@ const Right = styled.div`
   */
  const GroupHeader = ({logEntry}) => {
  
-     return(
-         <Container>
-             <FormattedDate date={logEntry.createdDate} fontSize="1.2rem" />{", "}{logEntry.owner}{", "}{logEntry.title}
-             <Right>
-                <span>{logEntry.id}</span>
-                {logEntry.attachments.length > 0 ? <FaPaperclip /> : null}
-             </Right>
-         </Container>
-     )
+    return (
+        <Stack
+            flexDirection="row"
+            justifyContent="center"
+            alignItems="center"
+            padding={0.5}
+            sx={{
+                backgroundColor: "grey.300"
+            }}
+        >
+            <FormattedDate date={logEntry.createdDate} />
+            <Typography>
+                {", "}{logEntry.owner}{", "}{logEntry.title}
+            </Typography>
+            {
+                logEntry.attachments.length > 0 
+                ? <Box marginLeft="auto"><AttachFileIcon /></Box> 
+                : null
+            }
+        </Stack>
+    );
  }
  
  export default GroupHeader;

--- a/src/components/LogDetails/GroupHeader.js
+++ b/src/components/LogDetails/GroupHeader.js
@@ -32,7 +32,7 @@ import AttachFileIcon from '@mui/icons-material/AttachFile';
     return (
         <Stack
             flexDirection="row"
-            justifyContent="center"
+            justifyContent="flex-start"
             alignItems="center"
             padding={0.5}
             sx={{

--- a/src/components/LogDetails/LogDetails.js
+++ b/src/components/LogDetails/LogDetails.js
@@ -22,22 +22,9 @@ import LogEntryGroupView from './LogEntryGroupView';
 import LogEntrySingleView from './LogEntrySingleView';
 import { useHref, useLocation } from "react-router-dom";
 import NavigationButtons from './NavigationButtons';
-import styled from 'styled-components';
-import { Button, Divider, Stack } from '@mui/material';
+import { Box, Button, Divider, Stack, styled } from '@mui/material';
 import { InternalButtonLink } from 'components/shared/InternalLink';
 import { useUser } from 'features/authSlice';
-
-
-const Container = styled.div`
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    overflow: hidden;
-`
-
-const LogViewContainer = styled.div`
-    overflow: hidden;
-`
 
 const StyledLogEntrySingleView = styled(LogEntrySingleView)`
     overflow: auto;
@@ -107,7 +94,13 @@ const LogDetails = ({
         />;
 
     return(
-        <Container className={className} id='logdetails-and-buttons'>
+        <Stack 
+            className={className} 
+            id='logdetails-and-buttons'
+            flexDirection="column"
+            width="100%"
+            overflow="hidden"
+        >
             <Stack flexDirection="row" gap={1} borderBottom={0} padding={1} flexWrap="wrap">
                 <NavigationButtons {...{
                     currentLogEntry,
@@ -130,10 +123,10 @@ const LogDetails = ({
                 </Button>
             </Stack>
             <Divider />
-            <LogViewContainer id='logdetails'>
+            <Box id='logdetails' overflow="hidden" >
                 {renderedLogView}
-            </LogViewContainer>
-        </Container>
+            </Box>
+        </Stack>
     )
     
 }

--- a/src/components/LogDetails/LogDetailsMetaData.js
+++ b/src/components/LogDetails/LogDetailsMetaData.js
@@ -16,83 +16,82 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
- import React from 'react';
- import customization from 'config/customization';
+import React from 'react';
+import customization from 'config/customization';
 import styled from 'styled-components';
-import { Link } from '@mui/material';
+import { Box, Link, Typography } from '@mui/material';
 import { Link as RouterLink } from "react-router-dom";
 import FormattedDate from 'components/shared/FormattedDate';
 
-const Container = styled.div`
-    font-size: 0.8rem;
-    padding-bottom: 1rem;
-`
+const Key = styled(Typography)({
+    textAlign: "right",
+    "&, & *": {
+        fontSize: "0.8rem"
+    }
+});
 
-const DetailRow = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-`
+const Value = styled(Typography)({
+    fontWeight: "bold",
+    "&, & *": {
+        fontSize: "0.8rem"
+    }
+});
 
-const Key = styled.div`
-    flex: 0 0 5rem;
-    text-align: right;
-`
+const CommaSeparatedList = ({list}) => {
+    if(list && list.length > 0) {
+        return (
+            <Typography component="span" fontWeight="inherit">
+                {
+                    list.join(", ")
+                }
+            </Typography>
+        )
+    }
 
-const Value = styled.div`
-    flex-grow: 1;
-    font-weight: bold;
-`
+    return null;
+}
 
-const LogDetailsMetaData = ({currentLogRecord}) => {
-        
-    const logbooks = currentLogRecord && currentLogRecord.logbooks.slice().sort((a, b) => a.name.localeCompare(b.name)).map((row, index) => {
-        if(index === currentLogRecord.logbooks.length - 1){
-            return(<span key={index}>{row.name}</span>);
-        }
-        else{
-            return (<span key={index}>{row.name},&nbsp;</span>);
-        }    
-    });
-
-    const tags = currentLogRecord && currentLogRecord.tags.slice().sort((a, b) => a.name.localeCompare(b.name)).map((row, index) => {
-        if(index === currentLogRecord.tags.length - 1){
-            return(<span key={index}>{row.name}</span>);
-        }
-        else{
-            return (<span key={index}>{row.name},&nbsp;</span>);
-        } 
-    });    
+const LogDetailsMetaData = ({currentLogRecord}) => {        
     
     return (
-        <Container>
-            <DetailRow>
-                <Key>Author</Key><Value data-testid="meta-author">{currentLogRecord.owner}</Value>
-            </DetailRow>
-            <DetailRow>
-                <Key>Created</Key>
-                <Value data-testid="meta-created">
-                    <span>
-                        <FormattedDate 
-                            date={currentLogRecord.modifyDate ? currentLogRecord.modifyDate : currentLogRecord.createdDate} 
-                            fontSize="0.8rem"
-                            fontWeight="inherit"
-                        />
-                        {" "}
-                        {currentLogRecord.modifyDate ? <Link component={RouterLink} to={`/logs/${currentLogRecord.id}/history`}>(edited)</Link> : null}
-                    </span>
-                </Value>
-            </DetailRow>
-            <DetailRow>
-                <Key>Logbooks</Key><Value data-testid="meta-logbooks">{logbooks}</Value>
-            </DetailRow>
-            <DetailRow>
-                <Key>Tags</Key><Value data-testid="meta-tags">{tags}</Value>
-            </DetailRow>
-            <DetailRow>
-                <Key>{customization.level}</Key><Value data-testid="meta-entrytype">{currentLogRecord.level}</Value>
-            </DetailRow>
-        </Container>
+        <Box
+            sx={{
+                display: "grid",
+                gridTemplateColumns: "max-content auto",
+                columnGap: 1,
+                justifyContent: "flex-start",
+            }}
+        >
+            <Key>Author</Key>
+            <Value data-testid="meta-author">{currentLogRecord.owner}</Value>
+            <Key>Created</Key>
+            <Value data-testid="meta-created">
+                <FormattedDate 
+                    date={currentLogRecord.modifyDate ? currentLogRecord.modifyDate : currentLogRecord.createdDate} 
+                    fontWeight="inherit"
+                />
+                {" "}
+                {currentLogRecord.modifyDate ? <Link component={RouterLink} to={`/logs/${currentLogRecord.id}/history`}>(edited)</Link> : null}
+            </Value>
+            <Key>Logbooks</Key>
+            <Value data-testid="meta-logbooks">
+                <CommaSeparatedList list={
+                    currentLogRecord?.logbooks
+                    ?.toSorted((a, b) => a.name.localeCompare(b.name))
+                    ?.map(it => it.name)
+                } />
+            </Value>
+            <Key>Tags</Key>
+            <Value data-testid="meta-tags">
+                <CommaSeparatedList list={
+                    currentLogRecord?.tags
+                    ?.toSorted((a, b) => a.name.localeCompare(b.name))
+                    ?.map(it => it.name)
+                } />
+            </Value>
+            <Key>{customization.level}</Key>
+            <Value data-testid="meta-entrytype">{currentLogRecord.level}</Value>
+        </Box>
     );
 
 }

--- a/src/components/LogDetails/LogEntryGroupView.js
+++ b/src/components/LogDetails/LogEntryGroupView.js
@@ -20,15 +20,15 @@ import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { updateCurrentLogEntry } from 'features/currentLogEntryReducer';
 import GroupHeader from './GroupHeader';
-import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import CommonmarkPreview from 'components/shared/CommonmarkPreview';
 import customization from 'config/customization';
 import { getLogEntryGroupId } from '../Properties/utils';
 import { sortByCreatedDate } from 'components/log/sort';
 import { ologApi } from 'api/ologApi';
+import { styled } from '@mui/material';
 
-const Container = styled.div`
+const Container = styled("div")`
     display: flex;
     height: 100%;
     flex-direction: column;
@@ -37,7 +37,7 @@ const Container = styled.div`
     overflow: auto;
 `
 
-const GroupContainer = styled.li`
+const GroupContainer = styled("li")`
     display: flex;
     flex-direction: column;
     gap: 0.25rem;

--- a/src/components/LogDetails/LogEntrySingleView.js
+++ b/src/components/LogDetails/LogEntrySingleView.js
@@ -20,20 +20,20 @@ import React from 'react';
 import ListGroup from 'components/shared/ListGroup';
 import Properties from '../Properties/Properties';
 import LogDetailsMetaData from './LogDetailsMetaData';
-import styled from 'styled-components';
 import Collapse from 'components/shared/Collapse';
 import { ListGroupItem } from 'components/shared/ListGroup';
 import CommonmarkPreview from 'components/shared/CommonmarkPreview';
 import customization from 'config/customization';
 import AttachmentImage, { isImage } from 'components/Attachment/AttachmentImage';
+import { Divider, styled } from '@mui/material';
 
-const Container = styled.div`
+const Container = styled("div")`
     padding: 0.5rem;
     height: 100%;
     overflow: auto;
 `
 
-const LogTitle = styled.div`
+const LogTitle = styled("div")`
     display: flex;
     justify-content: space-between;
 
@@ -41,12 +41,6 @@ const LogTitle = styled.div`
         font-size: 1.4rem;
         font-weight: normal;
     }
-`
-
-const Ruler = styled.hr`
-    border: none;
-    border-top: 1px solid ${({theme}) => theme.colors.light};
-    margin: 0.5rem 0;
 `
 
 const StyledCommonmarkPreview = styled(CommonmarkPreview)`
@@ -108,9 +102,9 @@ const LogEntrySingleView = ({currentLogEntry, className}) => {
                 <h2>{currentLogEntry.title}</h2>
                 <span>{currentLogEntry.id}</span>
             </LogTitle>
-            <Ruler />
+            <Divider sx={{marginY: 1}} />
             <LogDetailsMetaData currentLogRecord={currentLogEntry}/>
-            <Ruler />
+            <Divider sx={{marginY: 1}} />
             <StyledCommonmarkPreview commonmarkSrc={currentLogEntry.source} imageUrlPrefix={customization.APP_BASE_URL + "/"} />
             <Collapse title='Attachments'>
                 {currentLogEntry.attachments.length > 0 


### PR DESCRIPTION
## Summary of Changes
migrates the group and single entry log views to MUI

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [ ] Overall layout fills full width and height of viewport
- [ ] Pagination element doesn't overflow into other elements
