### PR TITLE
CSSTUDIO-2318: always use create date in log details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build
 # Cypress
 **/videos/*
 **/screenshots/*
+**/downloads/*

--- a/src/beta/components/log/LogDetails/LogHeader.js
+++ b/src/beta/components/log/LogDetails/LogHeader.js
@@ -6,6 +6,7 @@ import OlogAttachment from "components/log/EntryEditor/Description/OlogAttachmen
 import MetadataTable from "./MetadataTable";
 import LogDetailActionButton from "./LogDetailActionButton";
 import FormattedDate from "components/shared/FormattedDate";
+import EditIcon from '@mui/icons-material/Edit';
 
 const CreatedDate = ({log}) => {
 
@@ -14,7 +15,10 @@ const CreatedDate = ({log}) => {
             <>
                 <FormattedDate date={log.modifyDate} component="span" />
                 {" "}
-                <InternalLink to={`/beta/logs/${log.id}/history`}>(edited)</InternalLink>
+                <InternalLink to={`/beta/logs/${log.id}/history`}>
+                  <EditIcon fontSize="small" sx={{ verticalAlign: "text-top"}} />
+                  view history
+                </InternalLink>
             </>
         )
     }

--- a/src/components/LogDetails/LogDetailsMetaData.js
+++ b/src/components/LogDetails/LogDetailsMetaData.js
@@ -18,9 +18,10 @@
 
 import React from 'react';
 import customization from 'config/customization';
-import { Box, Link, Typography, styled } from '@mui/material';
-import { Link as RouterLink } from "react-router-dom";
+import { Box, Typography, styled } from '@mui/material';
 import FormattedDate from 'components/shared/FormattedDate';
+import EditIcon from '@mui/icons-material/Edit';
+import { InternalLink } from 'components/shared/Link';
 
 const Key = styled(Typography)({
     textAlign: "right"
@@ -63,18 +64,17 @@ const LogDetailsMetaData = ({currentLogRecord}) => {
                     date={currentLogRecord.createdDate} 
                     fontWeight="inherit"
                 />
-                {" "}
                 {currentLogRecord.modifyDate ? 
-                  <Link component={RouterLink} to={`/logs/${currentLogRecord.id}/history`}>
-                    {"("}
-                    edited
+                  <Typography component="span" fontStyle="italic">
                     {" "}
-                    <FormattedDate 
-                        date={currentLogRecord.modifyDate} 
-                        fontWeight="inherit"
-                    />
-                    {")"}
-                  </Link> 
+                    <InternalLink 
+                      to={`/logs/${currentLogRecord.id}/history`} 
+                      label={`View log history for ${currentLogRecord.title}`}
+                    >
+                      <EditIcon fontSize="small" sx={{ verticalAlign: "text-top"}} />
+                      view history
+                    </InternalLink>
+                  </Typography>
                   : null}
             </Value>
             <Key>Logbooks</Key>

--- a/src/components/LogDetails/LogDetailsMetaData.js
+++ b/src/components/LogDetails/LogDetailsMetaData.js
@@ -60,11 +60,22 @@ const LogDetailsMetaData = ({currentLogRecord}) => {
             <Key>Created</Key>
             <Value data-testid="meta-created">
                 <FormattedDate 
-                    date={currentLogRecord.modifyDate ? currentLogRecord.modifyDate : currentLogRecord.createdDate} 
+                    date={currentLogRecord.createdDate} 
                     fontWeight="inherit"
                 />
                 {" "}
-                {currentLogRecord.modifyDate ? <Link component={RouterLink} to={`/logs/${currentLogRecord.id}/history`}>(edited)</Link> : null}
+                {currentLogRecord.modifyDate ? 
+                  <Link component={RouterLink} to={`/logs/${currentLogRecord.id}/history`}>
+                    {"("}
+                    edited
+                    {" "}
+                    <FormattedDate 
+                        date={currentLogRecord.modifyDate} 
+                        fontWeight="inherit"
+                    />
+                    {")"}
+                  </Link> 
+                  : null}
             </Value>
             <Key>Logbooks</Key>
             <Value data-testid="meta-logbooks">

--- a/src/components/SearchResult/SearchResultItem.cy.js
+++ b/src/components/SearchResult/SearchResultItem.cy.js
@@ -30,7 +30,7 @@ describe('SearchResultListItem.cy.js', () => {
         );
     
         // the grouped entry will have the group icon
-        cy.findByRole('status', {name: 'grouped'}).should("exist");
+        cy.findByRole('status', {name: 'has replies'}).should("exist");
 
     })
     it('non-grouped item does not include a grouped icon', () => {
@@ -45,7 +45,7 @@ describe('SearchResultListItem.cy.js', () => {
         );
     
         // the grouped entry will not have the group icon
-        cy.findByRole('status', {name: 'grouped'}).should("not.exist");
+        cy.findByRole('status', {name: 'has replies'}).should("not.exist");
 
     })
     it('item with attachments include attachment icon', () => {

--- a/src/components/SearchResult/SearchResultItem.js
+++ b/src/components/SearchResult/SearchResultItem.js
@@ -21,6 +21,7 @@ import ReplyIcon from '@mui/icons-material/Reply';
 import AttachFileIcon from '@mui/icons-material/AttachFile';
 import { getLogEntryGroupId } from 'components/Properties/utils';
 import FormattedDate from 'components/shared/FormattedDate';
+import EditIcon from '@mui/icons-material/Edit';
 
 const LogInfo = styled("div")`
     display: flex;
@@ -55,8 +56,9 @@ const SearchResultItem = ({log}) => {
                     </Typography>
                 </Tooltip>
                 <Stack flexDirection="row" >
-                    {isGroupEntry ? <ReplyIcon titleAccess="grouped" role="status" /> : null}
+                    {isGroupEntry ? <ReplyIcon titleAccess="has replies" role="status" /> : null}
                     {log.attachments && log.attachments.length  !== 0 ? <AttachFileIcon titleAccess='has attachments' role='status' /> : null}
+                    {log.modifyDate ? <EditIcon titleAccess="has edits" /> : null}
                 </Stack>
             </Stack>
             <LogInfo>


### PR DESCRIPTION
## Summary of Changes
It can be confusing when in the search result list the create date is ABC, but in the log entry it is actually the edited date DEF. 
This updates the UX such that:

- the log entry always shows the create date
- if edited, the text becomes "(edited DEF)" in the same date format as the result lis

<img width="1319" alt="Screenshot 2024-03-26 at 16 27 33" src="https://github.com/Olog/phoebus-olog-web-client/assets/77395846/e038f2ad-ceb4-4a35-ae13-e53689917746">


## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [ ] Overall layout fills full width and height of viewport
- [ ] Pagination element doesn't overflow into other elements
