### PR TITLE
CSSTUDIO-2332: update beta log details ux

### DIFF
--- a/src/beta/components/log/EntryTypeChip.jsx
+++ b/src/beta/components/log/EntryTypeChip.jsx
@@ -1,0 +1,16 @@
+import { Chip } from "@mui/material";
+import React from "react";
+
+export const EntryTypeChip = ({name, ...props}) => {
+
+  return (
+    <Chip
+      label={name} 
+      aria-label={`has logbook ${name}`} 
+      size="small"
+      variant="outlined"
+      color="ologBlack" 
+      {...props} 
+    />
+  );
+};

--- a/src/beta/components/log/LogDetails/CreatedDate.js
+++ b/src/beta/components/log/LogDetails/CreatedDate.js
@@ -1,0 +1,26 @@
+import React from "react";
+import FormattedDate from "components/shared/FormattedDate";
+import { InternalLink } from "components/shared/Link";
+import EditIcon from '@mui/icons-material/Edit';
+
+
+export const CreatedDate = ({log}) => {
+
+  if(log.modifyDate) {
+      return (
+          <>
+              <FormattedDate date={log.modifyDate} component="span" />
+              {" "}
+              <InternalLink to={`/beta/logs/${log.id}/history`}>
+                <EditIcon fontSize="small" sx={{ verticalAlign: "text-top"}} />
+                view history
+              </InternalLink>
+          </>
+      )
+  }
+
+  return (
+      <FormattedDate date={log.createdDate} component="span" />
+  )
+
+}

--- a/src/beta/components/log/LogDetails/LogAttachmentsHeader.js
+++ b/src/beta/components/log/LogDetails/LogAttachmentsHeader.js
@@ -1,0 +1,20 @@
+import React from "react";
+import { Stack, Typography, styled } from "@mui/material";
+import AttachmentsGallery from "./AttachmentsGallery";
+import OlogAttachment from "components/log/EntryEditor/Description/OlogAttachment";
+
+export const LogAttachmentsHeader = styled(({log, className}) => {
+
+  if(!log?.attachments?.length > 0 ) {
+    return null;
+  }
+
+  return (
+    <Stack
+      className={className}
+    >
+      <Typography fontWeight="bold" >Attachments</Typography>
+      <AttachmentsGallery attachments={log?.attachments?.map(it => new OlogAttachment({attachment: it})) ?? []} />
+    </Stack>
+  )
+})({});

--- a/src/beta/components/log/LogDetails/LogDetailActionButton.js
+++ b/src/beta/components/log/LogDetails/LogDetailActionButton.js
@@ -21,15 +21,15 @@ const LogDetailActionButton = ({log}) => {
 
     const [anchorEl, setAnchorEl] = useState(null);
     const open = Boolean(anchorEl);
-    const onClick = (event) => {
-        setAnchorEl(event.currentTarget);
+    const onMenuButtonClick = (event) => {
+      setAnchorEl(event.currentTarget);
     };
-    const onClose = () => {
-        setAnchorEl(null);
+    const onMenuClose = () => {
+      setAnchorEl(null);
     };
 
     return (
-        <ButtonGroup variant="outlined">
+        <ButtonGroup variant="outlined" onClick={(event) => event.stopPropagation()}>
             <CopyUrlButton url={`${window.location.origin}/beta/logs/${log.id}`} />
             {user ? 
                 <>
@@ -38,16 +38,16 @@ const LogDetailActionButton = ({log}) => {
                         aria-controls={open ? "log-detail-action-menu" : undefined}
                         aria-haspopup="true"
                         aria-expanded={open ? "true" : undefined}
-                        onClick={onClick}
+                        onClick={onMenuButtonClick}
                         variant="outlined"
                     >
-                        <ExpandMoreIcon />
+                      <ExpandMoreIcon />
                     </Button>
                     <Menu
                         id="log-detail-action-menu"
                         anchorEl={anchorEl}
                         open={open}
-                        onClose={onClose}
+                        onClose={onMenuClose}
                     >
                         <MenuItemLink to={`/beta/logs/${log.id}/reply`} >
                             <ReplyIcon />

--- a/src/beta/components/log/LogDetails/LogDetails.js
+++ b/src/beta/components/log/LogDetails/LogDetails.js
@@ -1,9 +1,21 @@
-import { Stack, Typography, styled } from "@mui/material";
+import { Divider, Stack, Typography, styled } from "@mui/material";
 import React from "react";
-import LogHeader from "./LogHeader";
 import CommonmarkPreview from "components/shared/CommonmarkPreview";
 import customization from "config/customization";
 import LogProperty from "./LogProperty";
+import { LogAttachmentsHeader } from "./LogAttachmentsHeader";
+import MetadataTable from "./MetadataTable";
+import { LogbookChip } from "../LogbookChip";
+import { TagChip } from "../TagChip";
+import { EntryTypeChip } from "../EntryTypeChip";
+
+const ChipList = ({children}) => {
+  return (
+    <Stack flexDirection="row" gap={0.5} flexWrap="wrap">
+      {children}
+    </Stack>
+  )
+}
 
 const LogDetails = styled(({log, className}) => {
 
@@ -16,13 +28,22 @@ const LogDetails = styled(({log, className}) => {
                 overflow: "scroll"
             }} 
         >
-            <LogHeader log={log} />
-            <Typography variant="h4" component="h2">{log.title}</Typography>
-            <CommonmarkPreview commonmarkSrc={log.source} imageUrlPrefix={customization.APP_BASE_URL + "/"} />
-            { log?.properties
-                ?.filter(it => it.name.toLowerCase() !== "log entry group" && it.state.toLowerCase() === "active")
-                ?.map(it => <LogProperty property={it} key={it.name} />)
-            }
+          <LogAttachmentsHeader log={log} />
+          <Typography variant="h2">{log.title}</Typography>
+          <Divider />
+          <CommonmarkPreview commonmarkSrc={log.source} imageUrlPrefix={customization.APP_BASE_URL + "/"} />
+          { log?.properties
+              ?.filter(it => it.name.toLowerCase() !== "log entry group" && it.state.toLowerCase() === "active")
+              ?.map(it => <LogProperty property={it} key={it.name} />)
+          }
+          <Divider />
+          <MetadataTable
+            data={{
+              Logbooks: <ChipList>{log?.logbooks?.map(it => <LogbookChip key={it.name} name={it.name} />)}</ChipList>,
+              Tags: <ChipList>{log?.tags?.map(it => <TagChip key={it.name} name={it.name} />)}</ChipList>,
+              "Entry Type": <EntryTypeChip name={log?.level} />
+            }}
+          />
         </Stack>
     )
 

--- a/src/beta/components/log/LogDetails/LogDetailsWithReplies.js
+++ b/src/beta/components/log/LogDetails/LogDetailsWithReplies.js
@@ -2,12 +2,24 @@ import React, { useState } from "react";
 import { ologApi } from "api/ologApi";
 import { getLogEntryGroupId } from "components/Properties";
 import { sortByCreatedDate } from "components/log/sort";
-import { Accordion, AccordionDetails, AccordionSummary, Alert, Box, CircularProgress, Divider, Stack, Typography, styled } from "@mui/material";
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Box,
+  CircularProgress,
+  Divider,
+  Stack,
+  styled
+} from "@mui/material";
 import LogDetails from "./LogDetails";
-import AttachFileIcon from '@mui/icons-material/AttachFile';
-import FormattedDate from "components/shared/FormattedDate";
 import { useSearchPageParams } from "features/searchPageParamsReducer";
+import LogHeader from "./LogHeader";
+
+const StyledLogHeader = styled(LogHeader)({
+  width: "100%"
+});
 
 const LogDetailsAccordion = styled(({log, defaultExpanded=false, className}) => {
 
@@ -27,30 +39,13 @@ const LogDetailsAccordion = styled(({log, defaultExpanded=false, className}) => 
             className={className}
         >
             <AccordionSummary
-                expandIcon={<ExpandMoreIcon />}
                 aria-controls={`${log.id}-content`}
                 id={`${log.id}-header`}
                 sx={{
                     bgcolor: "grey.100"
                 }}
             >
-                <Box
-                    sx={{
-                        display: "grid",
-                        gridTemplateColumns: "1fr auto",
-                        gridTemplateRows: "1fr 1fr",
-                        columnGap: 2,
-                        rowGap: 1,
-                        width: "100%",
-                    }}
-                >
-                        <Typography variant="body1" fontWeight="bold" noWrap >{log.title}</Typography>
-                        <Stack flexDirection="row" justifyContent="flex-end" gap={0.5}>
-                            {log?.attachments?.length > 0 ? <AttachFileIcon /> : null }
-                        </Stack>
-                        <Typography variant="body2" fontWeight="italic" noWrap >{log.description?.slice(0, 100)}...</Typography>
-                        <FormattedDate date={log.createdDate} variant="button" />
-                </Box>
+              <StyledLogHeader log={log} />
             </AccordionSummary>
             <AccordionDetails>
                 <LogDetails log={log} />
@@ -109,7 +104,12 @@ const LogDetailsWithReplies = ({log}) => {
     }
     
     return (
+      <Stack>
+        <Box padding={1}>
+          <LogHeader log={log} />
+        </Box>
         <LogDetails log={log} />
+      </Stack>
     )
 
 }

--- a/src/beta/components/log/LogDetails/LogHeader.js
+++ b/src/beta/components/log/LogDetails/LogHeader.js
@@ -1,63 +1,29 @@
-import { Stack, Typography, styled } from "@mui/material";
-import { InternalLink } from "components/shared/Link";
 import React from "react";
-import AttachmentsGallery from "./AttachmentsGallery";
-import OlogAttachment from "components/log/EntryEditor/Description/OlogAttachment";
+import { Stack, styled } from "@mui/material";
 import MetadataTable from "./MetadataTable";
 import LogDetailActionButton from "./LogDetailActionButton";
-import FormattedDate from "components/shared/FormattedDate";
-import EditIcon from '@mui/icons-material/Edit';
+import { CreatedDate } from "./CreatedDate";
 
-const CreatedDate = ({log}) => {
-
-    if(log.modifyDate) {
-        return (
-            <>
-                <FormattedDate date={log.modifyDate} component="span" />
-                {" "}
-                <InternalLink to={`/beta/logs/${log.id}/history`}>
-                  <EditIcon fontSize="small" sx={{ verticalAlign: "text-top"}} />
-                  view history
-                </InternalLink>
-            </>
-        )
-    }
-
-    return (
-        <FormattedDate date={log.createdDate} component="span" />
-    )
-
-}
+const StyledMetadataTable = styled(MetadataTable)({
+  gridTemplateColumns: "max-content max-content"
+})
 
 const LogHeader = styled(({log, className}) => {
 
     return (
-        <Stack 
-            gap={1}
-            className={className}
-            padding={2}
-        >
-            <Stack flexDirection="row" justifyContent="space-between" alignItems="center">
-                <Typography variant="button" component="h3" >Log Information</Typography>
-                <LogDetailActionButton log={log} />
-            </Stack>
-            <MetadataTable data={{
-                "Author": log.owner,
-                "Created": <CreatedDate log={log} />,
-                "Logbooks": log?.logbooks.map(it => it.name).join(", "),
-                "Tags": log?.tags.map(it => it.name).join(", "),
-                "Entry Type": log.level
-            }} />
-            <Typography fontWeight="bold" >Attachments</Typography>
-            { log.attachments && log.attachments.length > 0 
-                ? <AttachmentsGallery attachments={log?.attachments?.map(it => new OlogAttachment({attachment: it})) ?? []} />
-                : <Typography fontStyle="italic" >(None)</Typography>
-            }
-        </Stack>
+      <Stack 
+        flexDirection="row" 
+        justifyContent="space-between" 
+        alignItems="center" 
+        className={className}
+      >
+        <StyledMetadataTable data={{
+            "Author": log.owner,
+            "Created": <CreatedDate log={log} />  
+        }} />                
+        <LogDetailActionButton log={log} />
+      </Stack>
     );
-})(({theme}) => ({
-    backgroundColor: `${theme.palette.primary.main}10`,
-    borderLeft: `${theme.palette.primary.main} solid 5px`
-}))
+})({})
 
 export default LogHeader;

--- a/src/beta/components/log/LogDetails/MetadataTable.js
+++ b/src/beta/components/log/LogDetails/MetadataTable.js
@@ -9,14 +9,17 @@ const Value = styled(Typography)({
     gridColumn: "span / span"
 });
 
-const MetadataTable = ({data}) => {
+const MetadataTable = styled(({data, className}) => {
 
     return (
-        <Box sx={{
+        <Box 
+          sx={{
             display: "grid",
             gridTemplateColumns: "max-content max-content max-content max-content",
             columnGap: 2
-        }}>
+          }}
+          className={className}
+        >
             {Object.entries(data).map(entry => 
                 <React.Fragment key={entry[0]}>
                     <Key>{entry[0]}</Key>
@@ -25,6 +28,6 @@ const MetadataTable = ({data}) => {
             )}
         </Box>
     )
-}
+})({})
 
 export default MetadataTable;

--- a/src/beta/components/log/LogbookChip.jsx
+++ b/src/beta/components/log/LogbookChip.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Chip } from "@mui/material";
+
+export const LogbookChip = ({name, ...props}) => {
+  return (
+    <Chip 
+      label={name} 
+      aria-label={`has logbook ${name}`} 
+      size="small"
+      variant="outlined"
+      color="ologPurple" 
+      {...props} 
+    />
+  );
+};

--- a/src/beta/components/log/TagChip.jsx
+++ b/src/beta/components/log/TagChip.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import LocalOfferIcon from '@mui/icons-material/LocalOffer';
+import { Chip } from "@mui/material";
+
+export const TagChip = ({name, ...props}) => {
+  return (
+    <Chip 
+      label={name} 
+      aria-label={`has tag ${name}`} 
+      icon={<LocalOfferIcon />} 
+      size="small"
+      variant="outlined"
+      color="ologOrange" 
+      {...props} 
+    />
+  );
+};

--- a/src/beta/components/search/SearchResultList/SearchResultSingleItem.jsx
+++ b/src/beta/components/search/SearchResultList/SearchResultSingleItem.jsx
@@ -1,35 +1,9 @@
 import React from "react";
-import { Box, Chip, Stack, Typography } from "@mui/material";
-import LocalOfferIcon from '@mui/icons-material/LocalOffer';
+import { Box, Stack, Typography } from "@mui/material";
 import FormattedDate from "components/shared/FormattedDate";
 import AttachFileIcon from '@mui/icons-material/AttachFile';
-
-const LogbookChip = ({name, ...props}) => {
-  return (
-    <Chip 
-      label={name} 
-      aria-label={`has logbook ${name}`} 
-      size="small"
-      variant="outlined"
-      color="ologPurple" 
-      {...props} 
-    />
-  )
-}
-
-const TagChip = ({name, ...props}) => {
-  return (
-    <Chip 
-      label={name} 
-      aria-label={`has tag ${name}`} 
-      icon={<LocalOfferIcon />} 
-      size="small"
-      variant="outlined"
-      color="ologOrange" 
-      {...props} 
-    />
-)
-}
+import { LogbookChip } from "beta/components/log/LogbookChip";
+import { TagChip } from "beta/components/log/TagChip";
 
 export const SearchResultSingleItem = ({log, selected, onClick}) => {
 

--- a/src/config/theme.js
+++ b/src/config/theme.js
@@ -29,7 +29,12 @@ theme = createTheme(theme, {
         },
         name: "ologCyan"
       }),
-      ologBlack: "#000000",
+      ologBlack: theme.palette.augmentColor({
+        color: {
+          main: "#000000"
+        },
+        name: "ologBlack"
+      }),
       ologWhite: theme.palette.augmentColor({
         color: {
           main: "#ffffff"


### PR DESCRIPTION
## Summary of Changes

- Makes the accordion / log details header more compact; only has author, created date, and attachments
- Moves rest of the metadata info to the bottom (logbooks, tags, EntryType)

With many replies:
<img width="1512" alt="Screenshot 2024-05-20 at 11 30 16" src="https://github.com/Olog/phoebus-olog-web-client/assets/77395846/283655da-1ff6-433d-9ef7-c6209dc8fa0b">

With no replies:
<img width="1512" alt="Screenshot 2024-05-20 at 11 30 28" src="https://github.com/Olog/phoebus-olog-web-client/assets/77395846/43469237-0982-4be9-a719-b5a1c65fd229">

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [ ] Overall layout fills full width and height of viewport
- [ ] Pagination element doesn't overflow into other elements
