### PR TITLE
CSSTUDIO-2334: refine beta date selector

### DIFF
--- a/src/beta/components/search/SimpleSearch/SimpleSearch.js
+++ b/src/beta/components/search/SimpleSearch/SimpleSearch.js
@@ -8,69 +8,71 @@ import { useDispatch } from "react-redux";
 
 const SimpleSearch = () => {
 
-    const searchParams = useSearchParams();
-    const dispatch = useDispatch();
+  const searchParams = useSearchParams();
+  const dispatch = useDispatch();
 
-    const { control, handleSubmit, setValue, watch, getValues } = useForm({
-        defaultValues: { query: searchParams?.query, start: searchParams?.start },
-        values: { query: searchParams?.query, start: searchParams?.start }
-    });
+  const { control, handleSubmit, setValue, watch, getValues } = useForm({
+    defaultValues: { query: searchParams?.query, start: searchParams?.start },
+    values: { query: searchParams?.query, start: searchParams?.start }
+  });
 
-    const dateValue = watch("start");
+  const startDateValue = watch("start");
 
-    const onAccept = (momentDate) => {
-        console.log({onAccept: momentDate})
-        setValue("start", momentDate.format(DATE_FORMAT));
-        onSubmit(getValues());
+  const onAccept = (momentDate) => {
+    console.log({onAccept: momentDate})
+    setValue("start", momentDate.format(DATE_FORMAT));
+    onSubmit(getValues());
+  }
+  const onReject = () => {
+    setValue("start", null);
+    onSubmit(getValues());
+  }
+
+  const onSubmit = (data) => {
+    console.log({onSubmit: data, searchParams})
+    const params = {
+      ...searchParams,
+      ...data
     }
-    const onReject = () => {
-        setValue("start", null);
-        onSubmit(getValues());
-    }
+    dispatch(forceUpdateSearchParams(params));
+  }
 
-    const onSubmit = (data) => {
-        console.log({onSubmit: data, searchParams})
-        const params = {
-            ...searchParams,
-            ...data
-        }
-        dispatch(forceUpdateSearchParams(params));
-    }
-
-    return (
-        <Stack 
-            component="form" 
-            gap={1}
-            width="100%" 
-            onSubmit={handleSubmit(onSubmit)}
-        >
-            <TextInput 
-                control={control}
-                name="query"
-                label="Search"
-                defaultValue=""
-                fullWidth
-                InputProps={{
-                    endAdornment:
-                        <InputAdornment position="end">
-                            <ButtonDatePicker 
-                                onAccept={onAccept} 
-                                ButtonFieldProps={{
-                                    inputProps: {
-                                        "aria-label": `Select start date/time}`
-                                    }
-                                }}
-                            />
-                        </InputAdornment>
+  return (
+    <Stack 
+      component="form" 
+      gap={1}
+      width="100%" 
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <TextInput 
+        control={control}
+        name="query"
+        label="Search"
+        defaultValue=""
+        fullWidth
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              <ButtonDatePicker 
+                onAccept={onAccept} 
+                ButtonFieldProps={{
+                  inputProps: {
+                    "aria-label": `Select start date/time`
+                  }
                 }}
-            />
-            <Stack flexDirection="row" justifyContent="flex-end">
-                {
-                    dateValue ? <Chip label={dateValue} size="small" onDelete={onReject} /> : null 
-                }
-            </Stack>
-        </Stack>
-    )
+              />
+            </InputAdornment>
+          )
+        }}
+      />
+      <Stack flexDirection="row" justifyContent="flex-end">
+        {
+          startDateValue ? <Chip label={`from: ${startDateValue}`} size="small" onDelete={onReject} /> : null 
+        }
+      </Stack>
+    </Stack>
+  )
+
 };
 
 export default SimpleSearch;


### PR DESCRIPTION
## Summary of Changes

Adds "from: " to the data pill to date search clearer:
<img width="398" alt="Screenshot 2024-05-20 at 13 45 04" src="https://github.com/Olog/phoebus-olog-web-client/assets/77395846/afe45588-115d-4f7f-9342-8e01a68d93f0">

Adding date-range picker being put on hold, as that component isn't freely available in MUI without a license.

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [ ] Overall layout fills full width and height of viewport
- [ ] Pagination element doesn't overflow into other elements
