### PR TITLE
CSSTUDIO-2373: fix images not displayed in some cases

### DIFF
--- a/src/components/Attachment/AttachmentImage.js
+++ b/src/components/Attachment/AttachmentImage.js
@@ -11,7 +11,7 @@ export const isImage = (attachment) => {
     if(attachment.file) {
         return attachment?.file?.type?.toLowerCase()?.startsWith("image");
     } else {
-        return attachment.fileMetadataDescription === "image";
+        return attachment.fileMetadataDescription?.toLowerCase()?.startsWith("image");
     }
 } 
 

--- a/src/components/log/EntryEditor/Description/OlogAttachment.js
+++ b/src/components/log/EntryEditor/Description/OlogAttachment.js
@@ -49,7 +49,7 @@ export default class OlogAttachment{
             }
             this.url = URL.createObjectURL(file);
         }   
-        if(this.fileMetadataDescription === "image") {
+        if(this.fileMetadataDescription?.toLowerCase()?.startsWith("image")) {
             this.isImage = true;
         }
     }


### PR DESCRIPTION
## Summary of Changes
In some cases, images don't display properly because their mime-type is image/{something} and a few pieces of code were asserting this was equal to "image" rather than starting with that text.

I'm aware there are two places in the code performing the check, however I'd rather plan tackling that in a separate body of work.

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [ ] Overall layout fills full width and height of viewport
- [ ] Pagination element doesn't overflow into other elements
