### PR TITLE
CSSTUDIO-2461: fix fail to redirect on create, edit, reply

### DIFF
--- a/src/api/ologApi.js
+++ b/src/api/ologApi.js
@@ -206,7 +206,7 @@ export const useVerifyLogExists = () => {
 
     return useCallback(async ({logRequest, logResult}) => {
         return withRetry({
-            fcn: async () => searchLogs({title: logResult.title, end: "now"}).unwrap(),
+            fcn: async () => searchLogs({title: `"${logResult.title}"`, end: "now"}).unwrap(),
             retries: 5,
             retryCondition: (retryRes) => {
                 // Retry if the entry we created isn't in the search results yet

--- a/src/beta/components/search/SearchResults.js
+++ b/src/beta/components/search/SearchResults.js
@@ -6,7 +6,6 @@ import { updateSearchPageParams, useSearchPageParams } from "features/searchPage
 import { updateSearchParams, useSearchParams } from "features/searchParamsReducer";
 import React, { useEffect, useMemo, useState } from "react";
 import { useDispatch } from "react-redux";
-import { useNavigate } from "react-router-dom";
 import SearchResultList from "./SearchResultList";
 import SimpleSearch from "./SimpleSearch";
 import { SortToggleButton } from "./SortToggleButton";
@@ -15,11 +14,12 @@ import { SearchParamsBadges } from "./SearchParamsBadges";
 import { AdvancedSearchDrawer } from "./SearchResultList/AdvancedSearchDrawer";
 import { useAdvancedSearch } from "features/advancedSearchReducer";
 import { withCacheBust } from "hooks/useSanitizedSearchParams";
+import useBetaNavigate from "hooks/useBetaNavigate";
 
 export const SearchResults = styled(({className}) => {
 
   const dispatch = useDispatch();
-  const navigate = useNavigate();
+  const navigate = useBetaNavigate();
 
   const { active: advancedSearchActive, fieldCount: advancedSearchFieldCount } = useAdvancedSearch();
   const currentLogEntry = useCurrentLogEntry();
@@ -88,7 +88,7 @@ export const SearchResults = styled(({className}) => {
 
   const onRowClick = (log) => {
     dispatch(updateCurrentLogEntry(log));
-    navigate(`/beta/logs/${log.id}`);
+    navigate(`/logs/${log.id}`);
   }
 
   const onPageChange = (event, page) => {

--- a/src/components/LogDetails/LogEntryGroupView.js
+++ b/src/components/LogDetails/LogEntryGroupView.js
@@ -20,13 +20,13 @@ import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { updateCurrentLogEntry } from 'features/currentLogEntryReducer';
 import GroupHeader from './GroupHeader';
-import { useNavigate } from 'react-router-dom';
 import CommonmarkPreview from 'components/shared/CommonmarkPreview';
 import customization from 'config/customization';
 import { getLogEntryGroupId } from '../Properties/utils';
 import { sortByCreatedDate } from 'components/log/sort';
 import { ologApi } from 'api/ologApi';
 import { styled } from '@mui/material';
+import useBetaNavigate from 'hooks/useBetaNavigate';
 
 const Container = styled("div")`
     display: flex;
@@ -55,7 +55,7 @@ const GroupContainer = styled("li")`
 const LogEntryGroupView = ({currentLogEntry, logGroupRecords, setLogGroupRecords, className}) => {
 
     const dispatch = useDispatch();
-    const navigate = useNavigate();
+    const navigate = useBetaNavigate();
     const [ getLogGroup ] = ologApi.endpoints.getLogGroup.useLazyQuery();
 
     useEffect(() => {

--- a/src/components/LogDetails/NavigationButtons.js
+++ b/src/components/LogDetails/NavigationButtons.js
@@ -18,10 +18,10 @@
 import { useState, useEffect } from 'react';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
-import { useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { updateCurrentLogEntry } from 'features/currentLogEntryReducer';
 import { Button, Stack } from '@mui/material';
+import useBetaNavigate from 'hooks/useBetaNavigate';
 
 const NavigationButtons = ({
     currentLogEntry,
@@ -29,7 +29,7 @@ const NavigationButtons = ({
     ...props
 }) => { 
 
-    const navigate = useNavigate();
+    const navigate = useBetaNavigate();
     const dispatch = useDispatch();
     const [previousLogEntry, setPreviousLogEntry] = useState();
     const [nextLogEntry, setNextLogEntry] = useState();

--- a/src/components/log/EditLog/EditLog.js
+++ b/src/components/log/EditLog/EditLog.js
@@ -2,16 +2,15 @@ import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import EntryEditor from "../EntryEditor";
 import { ologApi, useVerifyLogExists } from "api/ologApi";
-import { useLocation, useNavigate } from "react-router-dom";
 import { Backdrop, CircularProgress } from "@mui/material";
+import useBetaNavigate from "hooks/useBetaNavigate";
 
 const EditLog = ({log, isAuthenticated}) => {
 
     const [editInProgress, setEditInProgress] = useState(false);
     const [editLog] = ologApi.endpoints.editLog.useMutation();
     const verifyLogExists = useVerifyLogExists();
-    const navigate = useNavigate();
-    const location = useLocation();
+    const navigate = useBetaNavigate();
 
     const existingLogGroup = log?.properties?.filter(it => it.name === "Log Entry Group")?.at(0)?.value;
 
@@ -54,16 +53,13 @@ const EditLog = ({log, isAuthenticated}) => {
             // Edit the log
             const data = await editLog({log: body}).unwrap();
             try {
-                // Verify full edited/available
-                await verifyLogExists({logRequest: formData, logResult: data});
-                setEditInProgress(false);
-                if(location.pathname.startsWith("/beta")) {
-                    navigate(`/beta/logs/${data.id}`);
-                } else {
-                    navigate(`/logs/${data.id}`);
-                }
+              // Verify full edited/available
+              await verifyLogExists({logRequest: formData, logResult: data});
+              setEditInProgress(false);
             } catch (error) {
-                console.error("An error occured while checking log was edited", error);
+              console.error("An error occured while checking log was edited", error);
+            } finally {
+              navigate(`/logs/${data.id}`);
             }
         } catch (error) {
             if(error.response && (error.response.status === 401 || error.response.status === 403)){

--- a/src/components/log/ReplyLog/ReplyLog.js
+++ b/src/components/log/ReplyLog/ReplyLog.js
@@ -3,16 +3,15 @@ import { useForm } from "react-hook-form";
 import EntryEditor from "../EntryEditor";
 import customization from "config/customization";
 import { ologApi, useVerifyLogExists } from "api/ologApi";
-import { useLocation, useNavigate } from "react-router-dom";
 import { Backdrop, CircularProgress } from "@mui/material";
+import useBetaNavigate from "hooks/useBetaNavigate";
 
 const ReplyLog = ({log, isAuthenticated}) => {
 
     const [replyInProgress, setReplyInProgress] = useState(false);
     const [createLog] = ologApi.endpoints.createLog.useMutation();
     const verifyLogExists = useVerifyLogExists();
-    const navigate = useNavigate();
-    const location = useLocation();
+    const navigate = useBetaNavigate();
 
     const form = useForm({
         defaultValues: {
@@ -52,16 +51,13 @@ const ReplyLog = ({log, isAuthenticated}) => {
             // create (reply to) the log
             const data = await createLog({log: body, replyTo: log.id}).unwrap();
             try {
-                // verify log fully created before redirecting
-                await verifyLogExists({logRequest: formData, logResult: data});
-                setReplyInProgress(false);
-                if(location.pathname.startsWith("/beta")) {
-                    navigate(`/beta/logs/${data.id}`);
-                } else {
-                    navigate(`/logs/${data.id}`);
-                }
+              // verify log fully created before redirecting
+              await verifyLogExists({logRequest: formData, logResult: data});
+              setReplyInProgress(false);
             } catch (error) {
-                console.error("An error occured while checking log was created", error);
+              console.error("An error occured while checking log was created", error);
+            } finally {
+              navigate(`/logs/${data.id}`);
             }
         } catch (error) {
             if(error.response && (error.response.status === 401 || error.response.status === 403)){

--- a/src/hooks/useBetaNavigate.js
+++ b/src/hooks/useBetaNavigate.js
@@ -1,0 +1,21 @@
+import { useCallback } from "react";
+
+const { useLocation, useNavigate } = require("react-router-dom");
+
+const useBetaNavigate = () => {
+
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  return useCallback((path) => {
+
+    if(location.pathname.startsWith("/beta")) {
+      return navigate(`/beta${path}`);
+    } else {
+      return navigate(`${path}`);
+    }
+  
+  }, [location, navigate]);
+}
+
+export default useBetaNavigate;


### PR DESCRIPTION
## Summary of Changes

- adds redirect in create, edit, and reply to `finally` clause to ensure it always happens even when log verification fails
- centralizes beta navigation to custom hook

All component and end-to-end tests pass, please ignore GitHub flake.

## Visual Inspection
<!-- Before approving, view the app in your browser and verify it doesn't have any of the below problems. -->

- [ ] Conformance to Markdown styles: https://olog.esss.lu.se/Olog/help/CommonmarkCheatsheet
    - [ ] ...when viewing a log entry
    - [ ] ...when previewing HTML while writing a description
    - [ ] ...when viewing a log entry in the group view
- [ ] Scroll is possible (elements don't overflow their container, and they are scrollable)
    - [ ] ...search result list
    - [ ] ...log entry group view list
    - [ ] ...log entry single view
    - [ ] ...create new log entry page
- [ ] Overall layout fills full width and height of viewport
- [ ] Pagination element doesn't overflow into other elements
