### PR TITLE
More flexible customization of Level values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 # Base URL of the Backend OLOG service. API calls will be made
 # relative to this service URL.
 REACT_APP_BASE_URL=http://localhost:8080/Olog
+# Values in the "level" drop-down
+REACT_APP_LEVEL_VALUES=["Normal","Shift Start","Shift End","Fault","Beam Loss","Beam Configuration","Crew","Expert Intervention Call","Incident"]

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ default is `https://olog.readthedocs.io/en/latest/` |
 | REACT_APP_SUPPORT_HREF   | URL where support can be found for Olog. Shown on Help page only if provided. |
 | REACT_APP_VERSION        | Version string for Olog; default is the version defined in `package.json`. |
 | REACT_APP_VERSION_HREF   | URL where this version of Olog can be found. Shown on Help page only if provided. |
+| REACT_APP_LEVEL_VALUES   | List of values in the "Level" drop-down. NOTE: If set on the command line, quotes must be escaped, e.g. REACT_APP_LEVEL_VALUES=[\"foo\",\"bar\"] |
 
 ## Development 
 

--- a/src/components/shared/input/managed/EntryTypeSelect.js
+++ b/src/components/shared/input/managed/EntryTypeSelect.js
@@ -4,7 +4,6 @@ import { styled } from "@mui/material";
 import customization from "config/customization";
 
 const EntryTypeSelect = styled(({control, className, ...props}) => {
-
     return (
         <MultiSelect 
             className={className}
@@ -12,7 +11,7 @@ const EntryTypeSelect = styled(({control, className, ...props}) => {
             label={customization.level ?? "Entry Type"}
             control={control}
             defaultValue={customization.defaultLevel}
-            options={customization.levelValues}
+            options={JSON.parse(customization.levelValues)}
             {...props}
         />
     )

--- a/src/config/customization.js
+++ b/src/config/customization.js
@@ -28,17 +28,7 @@ let customization = {
     /**
      * Values for the "level" drop-down.
      */
-    levelValues: [
-        "Normal",
-        "Shift Start",
-        "Shift End",
-        "Fault",
-        "Beam Loss",
-        "Beam Configuration",
-        "Crew",
-        "Expert Intervention Call",
-        "Incident"
-    ],
+    levelValues: process.env.REACT_APP_LEVEL_VALUES,
 
     /**
      * Default "level" for new log entries


### PR DESCRIPTION
In order to support customization of the values in the "Level" drop-down in the editor, this PR removes the values from ```src/config/customnization.js``` to instead use environment variable ```REACT_APP_LEVEL_VALUES```.

If set on the command line, quotes must be escaped, e.g.:
```export REACT_APP_LEVEL_VALUES=[\"foo\",\"bar\"]```

As an alternative, a file ```.env``` in the root of the project structure can be used where environment variables can be defined (see README). In that case quotes should not be escaped:
```REACT_APP_LEVEL_VALUES=["foo","bar"]```