### PR TITLE
cleanup and small fixes

### DIFF
--- a/src/beta/components/log/LogDetails/LogDetails.jsx
+++ b/src/beta/components/log/LogDetails/LogDetails.jsx
@@ -2,7 +2,6 @@ import { Box, Divider, Stack, Typography } from "@mui/material";
 import { LogAttachmentsHeader } from "./LogAttachmentsHeader";
 import LogProperty from "./LogProperty";
 import MetadataTable from "./MetadataTable";
-import customization from "config/customization";
 import { CommonMark } from "components/shared/CommonMark";
 
 const LogDetails = ({ log, className }) => {
@@ -29,12 +28,7 @@ const LogDetails = ({ log, className }) => {
       >
         {log.title}
       </Typography>
-      {log.source && (
-        <CommonMark
-          commonmarkSrc={log.source}
-          imageUrlPrefix={customization.APP_BASE_URL + "/"}
-        />
-      )}
+      {log.source && <CommonMark commonmarkSrc={log.source} />}
       {log?.properties && filteredProperties.length > 0 && (
         <Box mt={2}>
           {filteredProperties.map((it, i) => (

--- a/src/beta/components/navigation/AppNavBar/AppNavBar.jsx
+++ b/src/beta/components/navigation/AppNavBar/AppNavBar.jsx
@@ -150,7 +150,7 @@ const AppNavBar = () => {
                         }
                         color="primary"
                       >
-                        <FilterAltIcon />
+                        <FilterAltIcon sx={{ color: "#616161" }} />
                       </Badge>
                     </IconButton>
                     <SortToggleButton

--- a/src/beta/components/search/AdvancedSearchDrawer.jsx
+++ b/src/beta/components/search/AdvancedSearchDrawer.jsx
@@ -81,7 +81,7 @@ export const AdvancedSearchDrawer = ({
             />
             <TextInput
               name="desc"
-              label="Description"
+              label="Text"
               control={control}
               defaultValue=""
             />

--- a/src/beta/components/search/AdvancedSearchDrawer.jsx
+++ b/src/beta/components/search/AdvancedSearchDrawer.jsx
@@ -60,6 +60,8 @@ export const AdvancedSearchDrawer = ({
             component="h2"
             variant="h4"
             id="advanced-search"
+            py={2}
+            px={1}
           >
             Filters
           </Typography>
@@ -69,6 +71,7 @@ export const AdvancedSearchDrawer = ({
             aria-labelledby="advanced-search"
             role="search"
             gap={1}
+            px={1}
           >
             <TextInput
               name="title"
@@ -78,7 +81,7 @@ export const AdvancedSearchDrawer = ({
             />
             <TextInput
               name="desc"
-              label="Text"
+              label="Description"
               control={control}
               defaultValue=""
             />

--- a/src/beta/components/search/SearchParamsBadges.jsx
+++ b/src/beta/components/search/SearchParamsBadges.jsx
@@ -95,7 +95,10 @@ export const SearchParamsBadges = () => {
           name="desc"
           value={desc}
           onDelete={() =>
-            onSearch({ ...searchParams, desc: defaultSearchParams.desc })
+            onSearch({
+              ...searchParams,
+              desc: defaultSearchParams.desc
+            })
           }
         />
       ) : null}

--- a/src/beta/components/search/SortToggleButton.jsx
+++ b/src/beta/components/search/SortToggleButton.jsx
@@ -7,6 +7,7 @@ export const SortToggleButton = ({ isDescending, onClick, label }) => {
   return (
     <IconButton
       aria-label={`sort by ${label}, ${isDescending ? "descending" : "ascending"}`}
+      sx={{ color: "#616161" }}
       onClick={onClick}
     >
       <Badge

--- a/src/components/log/EntryEditor/EntryEditor.jsx
+++ b/src/components/log/EntryEditor/EntryEditor.jsx
@@ -52,11 +52,15 @@ export const EntryEditor = ({
       px={4}
       pb={4}
       pt={2}
+      maxWidth="1000px"
+      margin="0 auto"
+      width="100%"
       height="fit-content"
     >
       <Typography
         component="h2"
         variant="h3"
+        py={2}
       >
         {title}
       </Typography>
@@ -106,6 +110,7 @@ export const EntryEditor = ({
           type="submit"
           variant="contained"
           disabled={submitDisabled}
+          sx={{ marginBottom: 4 }}
         >
           Submit
         </Button>

--- a/src/components/log/LogContainer.jsx
+++ b/src/components/log/LogContainer.jsx
@@ -7,7 +7,12 @@ const LogContainer = ({ id, renderLog }) => {
     data: log,
     isLoading,
     error
-  } = ologApi.endpoints.getLog.useQuery({ id }, { refetchOnFocus: true });
+  } = ologApi.endpoints.getLog.useQuery(
+    { id },
+    {
+      refetchOnMountOrArgChange: true
+    }
+  );
 
   if (isLoading) {
     return <LinearProgress width="100%" />;

--- a/src/components/shared/input/FileInput.jsx
+++ b/src/components/shared/input/FileInput.jsx
@@ -117,8 +117,7 @@ export const DroppableFileUploadInput = ({
       disabled={disabled}
     >
       <StyledClickableArea onClick={onClick}>
-        {/* <MdFileUpload size={'5rem'}/> */}
-        <Box fontSize="5rem">
+        <Box fontSize="2.5rem">
           {disabled ? (
             <CloudOffIcon fontSize="inherit" />
           ) : (


### PR DESCRIPTION
## Summary of Changes
- Refetch log details after edit
- Match color of filter and sort icons to the date icon in search field
- Give create log page a maxWidth and center fields
- Remove unused imageUrlPrefix prop
- Rename advanced filter field from "Text" to "Description", searching still works by using desc=...
- Made cloudIcon fit inside box for adding attachments
