### PR TITLE
Change the app name to Olog in manifest.json

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Olog",
+  "name": "Olog",
   "icons": [
     {
       "src": "favicon.ico",


### PR DESCRIPTION
The app name is change to Olog in this pull request. This name appears on the title of the PWA when users install it as web application on desktop.

![image](https://github.com/user-attachments/assets/1b14ec90-255e-411a-ba4b-32e142ecf3e9)
