### PR TITLE
CSSTUDIO-3171: Embed images

### DIFF
--- a/src/beta/utils/parseEmbeddedImages.js
+++ b/src/beta/utils/parseEmbeddedImages.js
@@ -1,0 +1,34 @@
+import customization from "src/config/customization";
+
+export const mdImageRegex = new RegExp(
+  "!\\[([^\\]]*)\\]\\(attachment/([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})\\)\\{width=(\\d+) height=(\\d+)\\}",
+  "g"
+);
+
+export const parseEmbeddedImages = (commonmarkSrc, attachedFiles) => {
+  let newContent = commonmarkSrc;
+
+  // Replaces the remote image url with a local blob url for preview purposes
+  const matches = [...commonmarkSrc.matchAll(mdImageRegex)];
+
+  matches.forEach((match) => {
+    const altText = match[1];
+    const id = match[2];
+    const width = match[3];
+    const height = match[4];
+
+    if (attachedFiles) {
+      const file = attachedFiles.find((file) => file.id === id);
+      newContent = newContent.replace(
+        match[0],
+        `![${altText}](${file.url}){width=${width} height=${height}}`
+      );
+    } else {
+      newContent = newContent.replace(
+        match[0],
+        `![${altText}](${customization.APP_BASE_URL}/attachment/${id}){width=${width} height=${height}}`
+      );
+    }
+  });
+  return newContent;
+};

--- a/src/components/log/EntryEditor/Description/Description.jsx
+++ b/src/components/log/EntryEditor/Description/Description.jsx
@@ -143,7 +143,7 @@ const Description = ({ form, attachmentsDisabled }) => {
   const addEmbeddedImage = (file, width, height) => {
     const id = uuidv4();
     appendAttachment(new OlogAttachment({ file, id }));
-    const imageMarkup = `![](${customization.APP_BASE_URL}/attachment/${id}){width=${width} height=${height}}`;
+    const imageMarkup = `![](attachment/${id}){width=${width} height=${height}}`;
     let description = getValues("description") || "";
     description += imageMarkup;
     setValue("description", description, {

--- a/src/components/log/EntryEditor/Description/HtmlPreviewModal.jsx
+++ b/src/components/log/EntryEditor/Description/HtmlPreviewModal.jsx
@@ -19,12 +19,7 @@
 import { useEffect, useState } from "react";
 import Modal from "../../../shared/Modal";
 import { CommonMark } from "../../../shared/CommonMark";
-import customization from "config/customization";
-
-const mdImageRegex = new RegExp(
-  `!\\[([^\\]]*)\\]\\(${customization.APP_BASE_URL}/attachment/([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})\\)\\{width=(\\d+) height=(\\d+)\\}`,
-  "g"
-);
+import { parseEmbeddedImages } from "src/beta/utils/parseEmbeddedImages";
 
 const HtmlPreviewModal = ({
   commonmarkSrc,
@@ -38,26 +33,9 @@ const HtmlPreviewModal = ({
 
   useEffect(() => {
     if (!useRemoteAttachments) {
-      let newContent = commonmarkSrc;
-
-      // Replaces the remote image url with a local blob url for preview purposes
-      const matches = [...commonmarkSrc.matchAll(mdImageRegex)];
-      matches.forEach((match) => {
-        const altText = match[1];
-        const id = match[2];
-        const width = match[3];
-        const height = match[4];
-        const file = attachedFiles.find((file) => file.id === id);
-
-        if (file) {
-          newContent = newContent.replace(
-            match[0],
-            `![${altText}](${file.url}){width=${width} height=${height}}`
-          );
-        }
-      });
-
-      setModifiedPreviewContent(newContent);
+      setModifiedPreviewContent(
+        parseEmbeddedImages(commonmarkSrc, attachedFiles)
+      );
     }
   }, [commonmarkSrc, attachedFiles, useRemoteAttachments]);
 

--- a/src/components/shared/CommonMark/CommonMark.jsx
+++ b/src/components/shared/CommonMark/CommonMark.jsx
@@ -4,6 +4,7 @@ import markdownit from "markdown-it";
 import markdownItAttrs from "markdown-it-attrs";
 import DOMPurify from "dompurify";
 import HtmlContent from "./HtmlContent";
+import { parseEmbeddedImages } from "src/beta/utils/parseEmbeddedImages";
 
 const md = markdownit().use(markdownItAttrs);
 
@@ -17,7 +18,8 @@ export const CommonMark = styled(
   ({ commonmarkSrc, className, isSummary, isPreview, ...props }) => {
     const [html, setHtml] = useState("");
     useEffect(() => {
-      const renderedHtml = md.render(commonmarkSrc);
+      const parsedEmbeddedImages = parseEmbeddedImages(commonmarkSrc);
+      const renderedHtml = md.render(parsedEmbeddedImages ?? commonmarkSrc);
       if (isPreview) {
         setHtml(renderedHtml);
       } else {


### PR DESCRIPTION
## Summary of Changes
- Changed logic to save attachment with relative url aka "attachment/..."
- Moved parsing logic into reusable function
- Used function for preview modal and implemented for rendering markdown in log entry details