### PR TITLE
CSSTUDIO-3192: Fix embed image bug

### DIFF
--- a/src/components/Attachment/AttachmentImage.jsx
+++ b/src/components/Attachment/AttachmentImage.jsx
@@ -1,6 +1,4 @@
 import { Box, Stack } from "@mui/material";
-import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
-import DownloadIcon from "@mui/icons-material/Download";
 
 export const isLocalFile = (attachment) => {
   return Boolean(attachment?.file);
@@ -16,7 +14,7 @@ export const isImage = (attachment) => {
   }
 };
 
-export const FileImage = ({ alt, className, ...props }) => {
+export const FileImage = ({ attachment, alt, className, ...props }) => {
   return (
     <Stack
       fontSize="5rem"
@@ -39,22 +37,14 @@ export const FileImage = ({ alt, className, ...props }) => {
           zIndex: 1
         }}
       />
-      <DownloadIcon
-        className="file-overlay"
-        sx={{
-          color: "gray",
-          width: "30px",
-          height: "30px",
-          position: "absolute",
-          left: "33px",
-          bottom: "25px",
-          zIndex: 2
+      <img
+        src={attachment.url}
+        alt={alt}
+        style={{
+          width: "100%",
+          objectFit: "contain",
+          overflow: "hidden"
         }}
-      />
-      <InsertDriveFileIcon
-        titleAccess={"file: " + alt}
-        fontSize="inherit"
-        sx={{ perserveAspectRatio: "none" }}
       />
     </Stack>
   );

--- a/src/components/log/EntryEditor/Description/Description.jsx
+++ b/src/components/log/EntryEditor/Description/Description.jsx
@@ -124,6 +124,15 @@ const Description = ({ form, attachmentsDisabled }) => {
     for (let item of items) {
       if (item.kind === "file" && item.type.match(/^image/)) {
         imageFile = item.getAsFile();
+
+        imageFile = new File(
+          [imageFile],
+          `${new Date().getTime()}-${imageFile.name}`,
+          {
+            type: imageFile.type,
+            lastModified: imageFile.lastModified
+          }
+        );
       }
     }
     if (imageFile) {


### PR DESCRIPTION
## Summary of Changes
- Fixed embed image bug by making the filename unique
- Made previews better by adding real image blob instead of gray file icon

How to test:

- Make screenshot and copy to clipboard (or copy image from desktop), try to paste into description field
- Embed image, do it multiple times with the same image
- Submit
- Feel free to mix it up with embed + normal attachments to make sure it's bulletproof