### PR TITLE
CSSTUDIO-3200: Expand on filter and scroll to top

### DIFF
--- a/src/components/AppNavBar/AppNavBar.jsx
+++ b/src/components/AppNavBar/AppNavBar.jsx
@@ -188,6 +188,10 @@ const AppNavBar = ({ advancedSearchOpen, setAdvancedSearchOpen }) => {
               onClick={() => {
                 dispatch(updateAdvancedSearch({ ...defaultSearchParams }));
                 setAdvancedSearchOpen(false);
+                document.getElementById("searchResultList").scrollTo({
+                  top: 0,
+                  behavior: "smooth"
+                });
               }}
               to="/"
               sx={{ padding: "8px", marginLeft: "-8px" }}

--- a/src/components/search/SearchResultList/SearchResultGroupItem/SearchResultGroupItem.jsx
+++ b/src/components/search/SearchResultList/SearchResultGroupItem/SearchResultGroupItem.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import {
   Box,
@@ -14,13 +14,17 @@ import { SearchResultSingleItem } from "..";
 import { getLogEntryGroupId } from "components/Properties";
 import { ologApi } from "api/ologApi";
 import { sortByCreatedDate } from "src/components/log/sort";
-import { useSearchParams } from "src/features/searchParamsReducer";
+import {
+  defaultSearchParams,
+  useSearchParams
+} from "src/features/searchParamsReducer";
 
 export const SearchResultGroupItem = styled(
   ({ log, onClick = () => {}, handleKeyDown, dateDescending }) => {
     const [expanded, setExpanded] = useState(false);
 
     const { start, end } = useSearchParams();
+    const searchParams = useSearchParams();
 
     const { id: paramLogId } = useParams();
     const currentLogEntryId = Number(paramLogId);
@@ -58,6 +62,16 @@ export const SearchResultGroupItem = styled(
       e.stopPropagation();
       setExpanded(!expanded);
     };
+
+    useEffect(() => {
+      if (
+        JSON.stringify(searchParams) !== JSON.stringify(defaultSearchParams)
+      ) {
+        setExpanded(true);
+      } else {
+        setExpanded(false);
+      }
+    }, [searchParams]);
 
     const ExpandIcon = () => (
       <Stack

--- a/src/components/search/SearchResultList/SearchResultList.jsx
+++ b/src/components/search/SearchResultList/SearchResultList.jsx
@@ -103,6 +103,7 @@ export const SearchResultList = styled(
         flex={2}
         px={0}
         overflow="auto"
+        id="searchResultList"
         className={`SearchResultList ${className}`}
       >
         {logsWithTrimmedGroupIds?.map((log) => {


### PR DESCRIPTION
## Summary of Changes
- Expand groups (show groups) when adding filters
- Clicking on home button scrolls list to top