### PR TITLE
CSSTUDIO-3389: Fix keyboard navigate /null

### DIFF
--- a/src/components/search/SearchResultList/SearchResultList.jsx
+++ b/src/components/search/SearchResultList/SearchResultList.jsx
@@ -65,7 +65,9 @@ export const SearchResultList = styled(
     const handleKeyDown = (e) => {
       if (e.key === "ArrowDown") {
         const nextSibling = e?.target?.nextElementSibling;
-        if (nextSibling) {
+        const id = nextSibling?.id ?? "";
+
+        if (id.includes("search-result-log")) {
           const logId = nextSibling.getAttribute("data-id");
           navigateToEntry(logId);
           nextSibling.focus();
@@ -74,7 +76,9 @@ export const SearchResultList = styled(
 
       if (e.key === "ArrowUp") {
         const prevSibling = e?.target?.previousElementSibling;
-        if (prevSibling) {
+        const id = prevSibling?.id ?? "";
+
+        if (id.includes("search-result-log")) {
           const logId = prevSibling.getAttribute("data-id");
           navigateToEntry(logId);
           prevSibling.focus();

--- a/src/components/search/SearchResultList/SearchResultSingleItem.jsx
+++ b/src/components/search/SearchResultList/SearchResultSingleItem.jsx
@@ -24,6 +24,7 @@ export const SearchResultSingleItem = ({
   const { condensedEntries } = useAdvancedSearch();
   return (
     <Stack
+      id={`search-result-log-${log.id}`}
       px={4}
       py={!condensedEntries ? 0.6 : 0.8}
       sx={{


### PR DESCRIPTION
## Summary of Changes
Before it would go to /null or crash if you were on the last or first in list. Now it does nothing.