### PR TITLE
Changed the name of attachmentDisabled to isEditing

### DIFF
--- a/src/components/log/EditLog/EditLog.jsx
+++ b/src/components/log/EditLog/EditLog.jsx
@@ -94,7 +94,7 @@ const EditLog = ({ log }) => {
           form,
           title: `Edit Log "${log?.title}"`,
           onSubmit,
-          attachmentsDisabled: true
+          isEditing: true
         }}
       />
     </>

--- a/src/components/log/EntryEditor/Description/Description.jsx
+++ b/src/components/log/EntryEditor/Description/Description.jsx
@@ -35,7 +35,7 @@ const RenderedAttachmentsContainer = styled("div")(
   })
 );
 
-const Description = ({ form, attachmentsDisabled }) => {
+const Description = ({ form, isEditing }) => {
   const { control, formState, getValues, setValue } = form;
   const descriptionRef = useRef();
 
@@ -138,7 +138,7 @@ const Description = ({ form, attachmentsDisabled }) => {
     for (let item of items) {
       if (item.kind === "file" && item.type.match(/^image/)) {
         const imageFile = item.getAsFile();
-        if (!attachmentsDisabled && imageFile) {
+        if (!isEditing && imageFile) {
           setInitialImage(imageFile);
           setShowEmbedImageDialog(true);
         }
@@ -250,7 +250,7 @@ const Description = ({ form, attachmentsDisabled }) => {
         >
           <Button
             variant="outlined"
-            disabled={attachmentsDisabled}
+            disabled={isEditing}
             onClick={() => setShowEmbedImageDialog(true)}
           >
             Embed Image
@@ -275,7 +275,7 @@ const Description = ({ form, attachmentsDisabled }) => {
             onFileChanged={onFileChanged}
             maxFileSizeMb={maxFileSizeMb}
             maxRequestSizeMb={maxRequestSizeMb}
-            disabled={attachmentsDisabled}
+            disabled={isEditing}
           />
           {parsedAttachments?.map((attachment, index) => {
             return (
@@ -283,7 +283,7 @@ const Description = ({ form, attachmentsDisabled }) => {
                 key={index}
                 attachment={attachment}
                 removeAttachment={() => onAttachmentRemoved(attachment, index)}
-                disabled={attachmentsDisabled}
+                disabled={isEditing}
               />
             );
           })}
@@ -307,7 +307,7 @@ const Description = ({ form, attachmentsDisabled }) => {
           showHtmlPreview={showHtmlPreview}
           setShowHtmlPreview={setShowHtmlPreview}
           commonmarkSrc={getValues("description")}
-          useRemoteAttachments={attachmentsDisabled}
+          useRemoteAttachments={isEditing}
           attachedFiles={attachments ?? []}
         />
       )}

--- a/src/components/log/EntryEditor/EntryEditor.jsx
+++ b/src/components/log/EntryEditor/EntryEditor.jsx
@@ -47,7 +47,7 @@ export const EntryEditor = ({
   title,
   onSubmit,
   submitDisabled,
-  attachmentsDisabled
+  isEditing
 }) => {
   const topElem = useRef();
   const navigate = useNavigate();
@@ -127,7 +127,7 @@ export const EntryEditor = ({
         </Typography>
       </Stack>
       <span ref={topElem} />
-      {attachmentsDisabled && (
+      {isEditing && (
         <Alert
           severity="info"
           sx={{ mb: 2 }}
@@ -213,7 +213,7 @@ export const EntryEditor = ({
         </Stack>
         <Description
           form={form}
-          attachmentsDisabled={attachmentsDisabled}
+          isEditing={isEditing}
         />
         <PropertyCollectionInput control={control} />
         <Stack


### PR DESCRIPTION
Changed the name of attachmentDisabled to a more generic isEditing variable to indicate the meaning of it.  

The choice is due to the attachmentDisabled being also used for, at least, one more thing other than disabling attachment and it also being a one to one to when  a user is editing an entry. This sohuld represent better the variable meaning and not change any of the functionalities


