### PR TITLE
CSSTUDIO-3539: Preview on empty description crashes app

### DIFF
--- a/src/components/log/EntryEditor/Description/Description.jsx
+++ b/src/components/log/EntryEditor/Description/Description.jsx
@@ -327,7 +327,7 @@ const Description = ({ form, isEditing }) => {
         <HtmlPreviewModal
           showHtmlPreview={showHtmlPreview}
           setShowHtmlPreview={setShowHtmlPreview}
-          commonmarkSrc={getValues("description")}
+          commonmarkSrc={getValues("description") ?? ""}
           useRemoteAttachments={isEditing}
           attachedFiles={attachments ?? []}
         />


### PR DESCRIPTION
## Summary of Changes
adds fallback value for the preview modal to avoid crash