### PR TITLE
CSSTUDIO-3484: Fix choose files bug Safari

### DIFF
--- a/src/components/log/EntryEditor/Description/Description.jsx
+++ b/src/components/log/EntryEditor/Description/Description.jsx
@@ -276,7 +276,7 @@ const Description = ({ form, isEditing }) => {
           <DroppableFileUploadInput
             id="attachments-upload"
             dragLabel="Drag Here"
-            browseLabel="Choose File(s)"
+            browseLabel="Choose file(s)"
             multiple
             onFileChanged={onFileChanged}
             maxFileSizeMb={maxFileSizeMb}

--- a/src/components/log/EntryEditor/Description/EmbedImageDialog.jsx
+++ b/src/components/log/EntryEditor/Description/EmbedImageDialog.jsx
@@ -174,7 +174,7 @@ const EmbedImageDialog = ({
                   onFileChanged={onFileChanged}
                   id="embed-image-upload"
                   dragLabel="Drag image here"
-                  browseLabel="Choose an image"
+                  browseLabel="Choose file(s)"
                   maxFileSizeMb={maxFileSizeMb}
                 />
               )}

--- a/src/components/log/EntryEditor/EntryEditor.jsx
+++ b/src/components/log/EntryEditor/EntryEditor.jsx
@@ -147,7 +147,9 @@ export const EntryEditor = ({
           gap={2}
         >
           <Stack
-            sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 2 }}
+            direction="row"
+            gap={2}
+            sx={{ "& > div": { flex: "1" } }}
           >
             <TextInput
               name="title"
@@ -189,7 +191,9 @@ export const EntryEditor = ({
             </Snackbar>
           </Stack>
           <Stack
-            sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 2 }}
+            direction="row"
+            gap={2}
+            sx={{ "& > div": { flex: "1" } }}
           >
             <LogbooksMultiSelect
               control={control}


### PR DESCRIPTION
The field wrappers were overflowing vertically and blocking the cursor.
